### PR TITLE
Added From... methods to BitmapFactory

### DIFF
--- a/Source/WriteableBitmapEx/BitmapFactory.cs
+++ b/Source/WriteableBitmapEx/BitmapFactory.cs
@@ -17,8 +17,16 @@
 #endregion
 
 using System;
+using System.IO;
+using System.Reflection;
 
 #if NETFX_CORE
+using Windows.Storage;
+using Windows.Storage.Streams;
+using System.Threading.Tasks;
+using Windows.Graphics.Imaging;
+using System.Runtime.InteropServices.WindowsRuntime;
+
 namespace Windows.UI.Xaml.Media.Imaging
 #else
 namespace System.Windows.Media.Imaging
@@ -42,7 +50,7 @@ namespace System.Windows.Media.Imaging
             if (pixelWidth < 1) pixelWidth = 1;
 
 #if SILVERLIGHT
-         return new WriteableBitmap(pixelWidth, pixelHeight);
+            return new WriteableBitmap(pixelWidth, pixelHeight);
 #elif WPF
             return new WriteableBitmap(pixelWidth, pixelHeight, 96.0, 96.0, PixelFormats.Pbgra32, null);
 #elif NETFX_CORE
@@ -72,5 +80,135 @@ namespace System.Windows.Media.Imaging
             return new WriteableBitmap(formatedBitmapSource);
         }
 #endif
+
+#if NETFX_CORE
+        /// <summary>
+        /// Loads an image from the applications content and returns a new WriteableBitmap.
+        /// </summary>
+        /// <param name="uri">The URI to the content file.</param>
+        /// <param name="pixelFormat">The pixel format of the stream data. If Unknown is provided as param, the default format of the BitmapDecoder is used.</param>
+        /// <returns>A new WriteableBitmap containing the pixel data.</returns>
+        public static async Task<WriteableBitmap> FromContent(Uri uri, BitmapPixelFormat pixelFormat = BitmapPixelFormat.Unknown)
+        {
+            // Decode pixel data
+            var file = await StorageFile.GetFileFromApplicationUriAsync(uri);
+            using (var stream = await file.OpenAsync(FileAccessMode.Read))
+            {
+                return await FromStream(stream);
+            }
+        }
+
+        /// <summary>
+        /// Loads the data from an image stream and returns a new WriteableBitmap.
+        /// </summary>
+        /// <param name="stream">The stream with the image data.</param>
+        /// <param name="pixelFormat">The pixel format of the stream data. If Unknown is provided as param, the default format of the BitmapDecoder is used.</param>
+        /// <returns>A new WriteableBitmap containing the pixel data.</returns>
+        public static async Task<WriteableBitmap> FromStream(Stream stream, BitmapPixelFormat pixelFormat = BitmapPixelFormat.Unknown)
+        {
+            using (var dstStream = new InMemoryRandomAccessStream())
+            {
+                await RandomAccessStream.CopyAsync(stream.AsInputStream(), dstStream);
+                return await FromStream(dstStream);
+            }
+        }
+
+        /// <summary>
+        /// Loads the data from an image stream and returns a new WriteableBitmap.
+        /// </summary>
+        /// <param name="stream">The stream with the image data.</param>
+        /// <param name="pixelFormat">The pixel format of the stream data. If Unknown is provided as param, the default format of the BitmapDecoder is used.</param>
+        /// <returns>A new WriteableBitmap containing the pixel data.</returns>
+        public static async Task<WriteableBitmap> FromStream(IRandomAccessStream stream, BitmapPixelFormat pixelFormat = BitmapPixelFormat.Unknown)
+        {
+            var decoder = await BitmapDecoder.CreateAsync(stream);
+            var transform = new BitmapTransform();
+            if (pixelFormat == BitmapPixelFormat.Unknown)
+            {
+                pixelFormat = decoder.BitmapPixelFormat;
+            }
+            var pixelData = await decoder.GetPixelDataAsync(pixelFormat, decoder.BitmapAlphaMode, transform, ExifOrientationMode.RespectExifOrientation, ColorManagementMode.ColorManageToSRgb);
+            var pixels = pixelData.DetachPixelData();
+
+            // Copy to WriteableBitmap
+            var bmp = new WriteableBitmap((int)decoder.OrientedPixelWidth, (int)decoder.OrientedPixelHeight);
+            using (var bmpStream = bmp.PixelBuffer.AsStream())
+            {
+                bmpStream.Seek(0, SeekOrigin.Begin);
+                bmpStream.Write(pixels, 0, (int)bmpStream.Length);
+                return bmp;
+            }
+        }
+
+        /// <summary>
+        /// Loads the data from a pixel buffer like the RenderTargetBitmap provides and returns a new WriteableBitmap.
+        /// </summary>
+        /// <param name="pixelBuffer">The source pixel buffer with the image data.</param>
+        /// <param name="width">The width of the image data.</param>
+        /// <param name="height">The height of the image data.</param>
+        /// <returns>A new WriteableBitmap containing the pixel data.</returns>
+        public static async Task<WriteableBitmap> FromPixelBuffer(IBuffer pixelBuffer, int width, int height)
+        {
+            // Copy to WriteableBitmap
+            var bmp = new WriteableBitmap(width, height);
+            using (var srcStream = pixelBuffer.AsStream())
+            {
+                using (var destStream = bmp.PixelBuffer.AsStream())
+                {
+                    srcStream.Seek(0, SeekOrigin.Begin);
+                    await srcStream.CopyToAsync(destStream);
+                }
+                return bmp;
+            }
+        }
+#else
+        /// <summary>
+        /// Loads an image from the applications resource file and returns a new WriteableBitmap.
+        /// </summary>
+        /// <param name="relativePath">Only the relative path to the resource file. The assembly name is retrieved automatically.</param>
+        /// <returns>A new WriteableBitmap containing the pixel data.</returns>
+        public static WriteableBitmap FromResource(string relativePath)
+        {
+            var fullName = Assembly.GetCallingAssembly().FullName;
+            var asmName = new AssemblyName(fullName).Name;
+            return FromContent(asmName + ";component/" + relativePath);
+        }
+
+        /// <summary>
+        /// Loads an image from the applications content and returns a new WriteableBitmap.
+        /// </summary>
+        /// <param name="relativePath">Only the relative path to the content file.</param>
+        /// <returns>A new WriteableBitmap containing the pixel data.</returns>
+        public static WriteableBitmap FromContent(string relativePath)
+        {
+            using (var bmpStream = Application.GetResourceStream(new Uri(relativePath, UriKind.Relative)).Stream)
+            {
+                return FromStream(bmpStream);
+            }
+        }
+
+        /// <summary>
+        /// Loads the data from an image stream and returns a new WriteableBitmap.
+        /// </summary>
+        /// <param name="stream">The stream with the image data.</param>
+        /// <returns>A new WriteableBitmap containing the pixel data.</returns>
+        public static WriteableBitmap FromStream(Stream stream)
+        {
+            var bmpi = new BitmapImage();
+#if SILVERLIGHT
+            bmpi.SetSource(stream);
+            bmpi.CreateOptions = BitmapCreateOptions.None;
+#elif WPF
+            bmpi.BeginInit();
+            bmpi.CreateOptions = BitmapCreateOptions.None;
+            bmpi.StreamSource = stream;
+            bmpi.EndInit();
+#endif
+            var bmp = new WriteableBitmap(bmpi);
+            bmpi.UriSource = null;
+            return bmp;
+        }
+#endif
+
     }
 }

--- a/Source/WriteableBitmapEx/WriteableBitmapConvertExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapConvertExtensions.cs
@@ -219,12 +219,10 @@ namespace System.Windows.Media.Imaging
       /// <param name="bmp">The WriteableBitmap.</param>
       /// <param name="relativePath">Only the relative path to the resource file. The assembly name is retrieved automatically.</param>
       /// <returns>A new WriteableBitmap containing the pixel data.</returns>
-      [Obsolete]
+      [Obsolete("Please use BitmapContext.FromResource instead of this FromResource method.")]
       public static WriteableBitmap FromResource(this WriteableBitmap bmp, string relativePath)
       {
-         var fullName = Assembly.GetCallingAssembly().FullName;
-         var asmName = new AssemblyName(fullName).Name;
-         return bmp.FromContent(asmName + ";component/" + relativePath);
+         return BitmapFactory.FromResource(relativePath);
       }
 #endif
 
@@ -236,15 +234,10 @@ namespace System.Windows.Media.Imaging
         /// <param name="uri">The URI to the content file.</param>
         /// <param name="pixelFormat">The pixel format of the stream data. If Unknown is provided as param, the default format of the BitmapDecoder is used.</param>
         /// <returns>A new WriteableBitmap containing the pixel data.</returns>
-        [Obsolete]
-        public static async Task<WriteableBitmap> FromContent(this WriteableBitmap bmp, Uri uri, BitmapPixelFormat pixelFormat = BitmapPixelFormat.Unknown)
+        [Obsolete("Please use BitmapContext.FromContent instead of this FromContent method.")]
+        public static Task<WriteableBitmap> FromContent(this WriteableBitmap bmp, Uri uri, BitmapPixelFormat pixelFormat = BitmapPixelFormat.Unknown)
         {
-            // Decode pixel data
-            var file = await StorageFile.GetFileFromApplicationUriAsync(uri);
-            using (var stream = await file.OpenAsync(FileAccessMode.Read))
-            {
-                return await FromStream(bmp, stream);
-            }
+            return BitmapFactory.FromContent(uri, pixelFormat);
         }
 
         /// <summary>
@@ -254,14 +247,10 @@ namespace System.Windows.Media.Imaging
         /// <param name="stream">The stream with the image data.</param>
         /// <param name="pixelFormat">The pixel format of the stream data. If Unknown is provided as param, the default format of the BitmapDecoder is used.</param>
         /// <returns>A new WriteableBitmap containing the pixel data.</returns>
-        [Obsolete]
-        public static async Task<WriteableBitmap> FromStream(this WriteableBitmap bmp, Stream stream, BitmapPixelFormat pixelFormat = BitmapPixelFormat.Unknown)
+        [Obsolete("Please use BitmapContext.FromStream instead of this FromStream method.")]
+        public static Task<WriteableBitmap> FromStream(this WriteableBitmap bmp, Stream stream, BitmapPixelFormat pixelFormat = BitmapPixelFormat.Unknown)
         {
-            using (var dstStream = new InMemoryRandomAccessStream())
-            {
-                await RandomAccessStream.CopyAsync(stream.AsInputStream(), dstStream);
-                return await FromStream(bmp, dstStream);
-            }
+            return BitmapFactory.FromStream(stream, pixelFormat);
         }
 
         /// <summary>
@@ -271,26 +260,10 @@ namespace System.Windows.Media.Imaging
         /// <param name="stream">The stream with the image data.</param>
         /// <param name="pixelFormat">The pixel format of the stream data. If Unknown is provided as param, the default format of the BitmapDecoder is used.</param>
         /// <returns>A new WriteableBitmap containing the pixel data.</returns>
-        [Obsolete]
-        public static async Task<WriteableBitmap> FromStream(this WriteableBitmap bmp, IRandomAccessStream stream, BitmapPixelFormat pixelFormat = BitmapPixelFormat.Unknown)
+        [Obsolete("Please use BitmapContext.FromStream instead of this FromStream method.")]
+        public static Task<WriteableBitmap> FromStream(this WriteableBitmap bmp, IRandomAccessStream stream, BitmapPixelFormat pixelFormat = BitmapPixelFormat.Unknown)
         {
-            var decoder = await BitmapDecoder.CreateAsync(stream);
-            var transform = new BitmapTransform();
-            if (pixelFormat == BitmapPixelFormat.Unknown)
-            {
-                pixelFormat = decoder.BitmapPixelFormat;
-            }
-            var pixelData = await decoder.GetPixelDataAsync(pixelFormat, decoder.BitmapAlphaMode, transform, ExifOrientationMode.RespectExifOrientation, ColorManagementMode.ColorManageToSRgb);
-            var pixels = pixelData.DetachPixelData();
-
-            // Copy to WriteableBitmap
-            bmp = new WriteableBitmap((int)decoder.OrientedPixelWidth, (int)decoder.OrientedPixelHeight);
-            using (var bmpStream = bmp.PixelBuffer.AsStream())
-            {
-                bmpStream.Seek(0, SeekOrigin.Begin);
-                bmpStream.Write(pixels, 0, (int)bmpStream.Length);
-                return bmp;
-            }
+            return BitmapFactory.FromStream(stream, pixelFormat);
         }
 
         /// <summary>
@@ -333,20 +306,10 @@ namespace System.Windows.Media.Imaging
         /// <param name="width">The width of the image data.</param>
         /// <param name="height">The height of the image data.</param>
         /// <returns>A new WriteableBitmap containing the pixel data.</returns>
-        [Obsolete]
-        public static async Task<WriteableBitmap> FromPixelBuffer(this WriteableBitmap bmp, IBuffer pixelBuffer, int width, int height)
+        [Obsolete("Please use BitmapContext.FromPixelBuffer instead of this FromPixelBuffer method.")]
+        public static Task<WriteableBitmap> FromPixelBuffer(this WriteableBitmap bmp, IBuffer pixelBuffer, int width, int height)
         {
-            // Copy to WriteableBitmap
-            bmp = new WriteableBitmap(width, height);
-            using (var srcStream = pixelBuffer.AsStream())
-            {
-                using (var destStream = bmp.PixelBuffer.AsStream())
-                {
-                    srcStream.Seek(0, SeekOrigin.Begin);
-                    await srcStream.CopyToAsync(destStream);
-                }
-                return bmp;
-            }
+            return BitmapFactory.FromPixelBuffer(pixelBuffer, width, height);
         }
 #else
       /// <summary>
@@ -355,13 +318,10 @@ namespace System.Windows.Media.Imaging
       /// <param name="bmp">The WriteableBitmap.</param>
       /// <param name="relativePath">Only the relative path to the content file.</param>
       /// <returns>A new WriteableBitmap containing the pixel data.</returns>
-      [Obsolete]
+      [Obsolete("Please use BitmapContext.FromContent instead of this FromContent method.")]
       public static WriteableBitmap FromContent(this WriteableBitmap bmp, string relativePath)
       {
-        using (var bmpStream = Application.GetResourceStream(new Uri(relativePath, UriKind.Relative)).Stream)
-         {
-            return FromStream(bmp, bmpStream);
-         }
+         return BitmapFactory.FromContent(relativePath);
       }
 
       /// <summary>
@@ -370,22 +330,10 @@ namespace System.Windows.Media.Imaging
       /// <param name="bmp">The WriteableBitmap.</param>
       /// <param name="stream">The stream with the image data.</param>
       /// <returns>A new WriteableBitmap containing the pixel data.</returns>
-      [Obsolete]
+      [Obsolete("Please use BitmapContext.FromStream instead of this FromStream method.")]
       public static WriteableBitmap FromStream(this WriteableBitmap bmp, Stream stream)
       {
-         var bmpi = new BitmapImage();
-#if SILVERLIGHT
-         bmpi.SetSource(stream);
-         bmpi.CreateOptions = BitmapCreateOptions.None;
-#elif WPF
-         bmpi.BeginInit();
-         bmpi.CreateOptions = BitmapCreateOptions.None;
-         bmpi.StreamSource = stream;
-         bmpi.EndInit();
-#endif
-         bmp = new WriteableBitmap(bmpi);   
-         bmpi.UriSource = null;
-         return bmp;
+         return BitmapFactory.FromStream(stream);
       }
 #endif
 

--- a/Source/WriteableBitmapEx/WriteableBitmapConvertExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapConvertExtensions.cs
@@ -219,6 +219,7 @@ namespace System.Windows.Media.Imaging
       /// <param name="bmp">The WriteableBitmap.</param>
       /// <param name="relativePath">Only the relative path to the resource file. The assembly name is retrieved automatically.</param>
       /// <returns>A new WriteableBitmap containing the pixel data.</returns>
+      [Obsolete]
       public static WriteableBitmap FromResource(this WriteableBitmap bmp, string relativePath)
       {
          var fullName = Assembly.GetCallingAssembly().FullName;
@@ -235,6 +236,7 @@ namespace System.Windows.Media.Imaging
         /// <param name="uri">The URI to the content file.</param>
         /// <param name="pixelFormat">The pixel format of the stream data. If Unknown is provided as param, the default format of the BitmapDecoder is used.</param>
         /// <returns>A new WriteableBitmap containing the pixel data.</returns>
+        [Obsolete]
         public static async Task<WriteableBitmap> FromContent(this WriteableBitmap bmp, Uri uri, BitmapPixelFormat pixelFormat = BitmapPixelFormat.Unknown)
         {
             // Decode pixel data
@@ -252,6 +254,7 @@ namespace System.Windows.Media.Imaging
         /// <param name="stream">The stream with the image data.</param>
         /// <param name="pixelFormat">The pixel format of the stream data. If Unknown is provided as param, the default format of the BitmapDecoder is used.</param>
         /// <returns>A new WriteableBitmap containing the pixel data.</returns>
+        [Obsolete]
         public static async Task<WriteableBitmap> FromStream(this WriteableBitmap bmp, Stream stream, BitmapPixelFormat pixelFormat = BitmapPixelFormat.Unknown)
         {
             using (var dstStream = new InMemoryRandomAccessStream())
@@ -268,6 +271,7 @@ namespace System.Windows.Media.Imaging
         /// <param name="stream">The stream with the image data.</param>
         /// <param name="pixelFormat">The pixel format of the stream data. If Unknown is provided as param, the default format of the BitmapDecoder is used.</param>
         /// <returns>A new WriteableBitmap containing the pixel data.</returns>
+        [Obsolete]
         public static async Task<WriteableBitmap> FromStream(this WriteableBitmap bmp, IRandomAccessStream stream, BitmapPixelFormat pixelFormat = BitmapPixelFormat.Unknown)
         {
             var decoder = await BitmapDecoder.CreateAsync(stream);
@@ -329,6 +333,7 @@ namespace System.Windows.Media.Imaging
         /// <param name="width">The width of the image data.</param>
         /// <param name="height">The height of the image data.</param>
         /// <returns>A new WriteableBitmap containing the pixel data.</returns>
+        [Obsolete]
         public static async Task<WriteableBitmap> FromPixelBuffer(this WriteableBitmap bmp, IBuffer pixelBuffer, int width, int height)
         {
             // Copy to WriteableBitmap
@@ -350,6 +355,7 @@ namespace System.Windows.Media.Imaging
       /// <param name="bmp">The WriteableBitmap.</param>
       /// <param name="relativePath">Only the relative path to the content file.</param>
       /// <returns>A new WriteableBitmap containing the pixel data.</returns>
+      [Obsolete]
       public static WriteableBitmap FromContent(this WriteableBitmap bmp, string relativePath)
       {
         using (var bmpStream = Application.GetResourceStream(new Uri(relativePath, UriKind.Relative)).Stream)
@@ -364,6 +370,7 @@ namespace System.Windows.Media.Imaging
       /// <param name="bmp">The WriteableBitmap.</param>
       /// <param name="stream">The stream with the image data.</param>
       /// <returns>A new WriteableBitmap containing the pixel data.</returns>
+      [Obsolete]
       public static WriteableBitmap FromStream(this WriteableBitmap bmp, Stream stream)
       {
          var bmpi = new BitmapImage();

--- a/Source/WriteableBitmapExBlitAlphaRepro.WinPhone8/MainPage.xaml.cs
+++ b/Source/WriteableBitmapExBlitAlphaRepro.WinPhone8/MainPage.xaml.cs
@@ -48,7 +48,7 @@ namespace PhoneApp1
 
         public static async Task<WriteableBitmap> LoadFromUri(string path)
         {
-            return new WriteableBitmap(1, 1).FromContent(path);
+            return BitmapFactory.FromContent(path);
         }
 
         // Sample code for building a localized ApplicationBar

--- a/Source/WriteableBitmapExBlitAlphaRepro.WinRT/MainPage.xaml.cs
+++ b/Source/WriteableBitmapExBlitAlphaRepro.WinRT/MainPage.xaml.cs
@@ -72,7 +72,7 @@ namespace WriteableBitmapExBlitAlphaRepro.WinRT
 
             using (var fileStream = await file.OpenAsync(FileAccessMode.Read))
             {
-                var wb = await new WriteableBitmap(1, 1).FromStream(fileStream);
+                var wb = await BitmapFactory.FromStream(fileStream);
                 return wb;
             }
         }

--- a/Source/WriteableBitmapExBlitAlphaRepro.Wpf/MainWindow.xaml.cs
+++ b/Source/WriteableBitmapExBlitAlphaRepro.Wpf/MainWindow.xaml.cs
@@ -34,7 +34,7 @@ namespace WriteableBitmapExBlitAlphaRepro.Wpf
         {
             using (var fileStream = File.OpenRead(fileName))
             {
-                var wb = BitmapFactory.New(1, 1).FromStream(fileStream);
+                var wb = BitmapFactory.FromStream(fileStream);
                 return wb;
             }
         }

--- a/Source/WriteableBitmapExBlitSample.WinRT/MainPage.xaml.cs
+++ b/Source/WriteableBitmapExBlitSample.WinRT/MainPage.xaml.cs
@@ -82,7 +82,7 @@ namespace WriteableBitmapExBlitSample.WinRT
         async Task<WriteableBitmap> LoadBitmap(string path)
         {
             Uri imageUri = new Uri(BaseUri, path);
-            var bmp = await BitmapFactory.New(1, 1).FromContent(imageUri);
+            var bmp = await BitmapFactory.FromContent(imageUri);
             return bmp;
         }
 

--- a/Source/WriteableBitmapExBlitSample.Wpf/MainWindow.xaml.cs
+++ b/Source/WriteableBitmapExBlitSample.Wpf/MainWindow.xaml.cs
@@ -51,7 +51,7 @@ namespace WriteableBitmapExBlitSample.Wpf
         {
             using (var s = Application.GetResourceStream(new Uri(path, UriKind.Relative)).Stream)
             {
-                var wb = BitmapFactory.New(1, 1).FromStream(s);
+                var wb = BitmapFactory.FromStream(s);
                 return BitmapFactory.ConvertToPbgra32Format(wb);
             }
         }


### PR DESCRIPTION
Hello @teichgraf ,

I hope you don't mind, but since you have (finally :-) ) moved *WriteableBitmapEx* to *Github* it has become easier for me to provide a decent patch. So here is now my proposal for placing the different `From...` as regular static methods in `BitmapFactory` as a regular Pull Request (originally posted as CodePlex patch 17504).

This PR illustrates how the `WriteableBitmap` initialization methods from resources (*Content*, *Stream* etc.) can be moved from `WriteableBitmapConvertExtensions` to `BitmapFactory` for (in my opinion) a more intuitive API.

The methods are changed from extension methods to regular static methods, returning the `WriteableBitmap` that is created inside the method.

The issue was initially raised in the discussion forum [here](https://writeablebitmapex.codeplex.com/discussions/637453).

For backwards compatibility I have not removed the original extension methods, but I have decorated them with an `[Obsolete]` attribute.

As a proof-of-concept, I have also updated the samples where these convert extension methods were previously used.

I hope you find this PR worthwhile to merge.

Best regards,
Anders @ Cureos