### PR TITLE
Dropped unsafe keyword in WPF

### DIFF
--- a/Source/WriteableBitmapEx.Wpf/IntPtrExtender.cs
+++ b/Source/WriteableBitmapEx.Wpf/IntPtrExtender.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace System.Windows.Media.Imaging
+{
+	internal static class IntPtrExtender
+	{
+		/// <summary>
+		/// Add offset (size of type T * count) to the value of a pointer to T.
+		/// </summary>
+		/// <param name="ptr">The pointer to add to.</param>
+		/// <param name="count">Number of T's to offset the pointer by.</param>
+		/// <returns>A new pointer that reflects the offset to the pointer.</returns>
+		public static IntPtr Add<T>( this IntPtr ptr, int count )
+		{
+			int offset = Marshal.SizeOf( typeof( T ) ) * count;
+			return ( IntPtr.Add( ptr, offset ) );
+		}
+	}
+}

--- a/Source/WriteableBitmapEx.Wpf/NativeMethods.cs
+++ b/Source/WriteableBitmapEx.Wpf/NativeMethods.cs
@@ -1,18 +1,19 @@
 ﻿using System;
 using System.Runtime;
 using System.Runtime.InteropServices;
+using System.Windows.Media.Imaging;
 
 namespace System.Windows.Media.Imaging
 {
     internal static class NativeMethods
     {
         [TargetedPatchingOptOut("Internal method only, inlined across NGen boundaries for performance reasons")]
-        internal static unsafe void CopyUnmanagedMemory(byte* srcPtr, int srcOffset, byte* dstPtr, int dstOffset, int count)
+        internal static void CopyUnmanagedMemory(IntPtr srcPtr, int srcOffset, IntPtr dstPtr, int dstOffset, int count)
         {
-            srcPtr += srcOffset;
-            dstPtr += dstOffset;
+			srcPtr = srcPtr.Add<byte>( srcOffset );
+			dstPtr = dstPtr.Add<byte>( dstOffset );
 
-            memcpy(dstPtr, srcPtr, count);
+			memcpy(dstPtr, srcPtr, (UInt32)count );
         }
 
         [TargetedPatchingOptOut("Internal method only, inlined across NGen boundaries for performance reasons")]
@@ -21,18 +22,28 @@ namespace System.Windows.Media.Imaging
             memset(dst, filler, count);
         }
 
-        // Win32 memory copy function
-        //[DllImport("ntdll.dll")]
-        [DllImport("msvcrt.dll", EntryPoint = "memcpy", CallingConvention = CallingConvention.Cdecl, SetLastError = false)]
-        private static extern unsafe byte* memcpy(
-            byte* dst,
-            byte* src,
-            int count);
-        
-        // Win32 memory set function
-        //[DllImport("ntdll.dll")]
-        //[DllImport("coredll.dll", EntryPoint = "memset", SetLastError = false)]
-        [DllImport("msvcrt.dll", EntryPoint = "memset", CallingConvention = CallingConvention.Cdecl, SetLastError = false)]
+		// Win32 memory copy function
+		/// <summary>
+		/// Copies characters between buffers.
+		/// </summary>
+		/// <param name="dst">New buffer</param>
+		/// <param name="src">Buffer to copy from</param>
+		/// <param name="count">Number of characters to copy</param>
+		/// <returns>returns the value of dest.</returns>
+		[DllImport("msvcrt.dll", EntryPoint = "memcpy", CallingConvention = CallingConvention.Cdecl, SetLastError = false)]
+        private static extern IntPtr memcpy(
+			[In] IntPtr dst,
+			[In] IntPtr src,
+			[In] UInt32 count );
+
+		// Win32 memory set function
+		/// <summary>
+		/// Sets buffers to a specified character.
+		/// </summary>
+		/// <param name="dst">Pointer to destination</param>
+		/// <param name="c">Character to set</param>
+		/// <param name="count">Number of characters</param>
+		[DllImport("msvcrt.dll", EntryPoint = "memset", CallingConvention = CallingConvention.Cdecl, SetLastError = false)]
         private static extern void memset(
             IntPtr dst,
             int filler,

--- a/Source/WriteableBitmapEx.Wpf/WriteableBitmapEx.Wpf.csproj
+++ b/Source/WriteableBitmapEx.Wpf/WriteableBitmapEx.Wpf.csproj
@@ -21,7 +21,7 @@
     <DefineConstants>TRACE;DEBUG;WPF</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -95,6 +95,7 @@
     <Compile Include="..\WriteableBitmapEx\WriteableBitmapLineExtensions.cs">
       <Link>WriteableBitmapLineExtensions.cs</Link>
     </Compile>
+    <Compile Include="IntPtrExtender.cs" />
     <Compile Include="NativeMethods.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Source/WriteableBitmapEx/WriteableBitmapAntialiasingExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapAntialiasingExtensions.cs
@@ -16,6 +16,7 @@
 //
 #endregion
 using System;
+using System.Runtime.InteropServices;
 
 #if NETFX_CORE
 using Windows.Foundation;
@@ -30,11 +31,7 @@ namespace System.Windows.Media.Imaging
     /// <summary>
     /// Collection of draw extension methods for the Silverlight WriteableBitmap class.
     /// </summary>
-    public
-#if !SILVERLIGHT 
-       unsafe 
-#endif
- static partial class WriteableBitmapExtensions
+    public static partial class WriteableBitmapExtensions
     {
         private static readonly int[] leftEdgeX = new int[8192];
         private static readonly int[] rightEdgeX = new int[8192];
@@ -95,9 +92,10 @@ namespace System.Windows.Media.Imaging
                         gs = g;
                         bs = b;
 
-                        d = buffer[y * width + x];
+						// d = buffer[y * width + x];
+						d = Marshal.ReadInt32( buffer.Add<Int32>( y * width + x ) );
 
-                        rd = (byte)((d & 0x00ff0000) >> 16);
+						rd = (byte)((d & 0x00ff0000) >> 16);
                         gd = (byte)((d & 0x0000ff00) >> 8);
                         bd = (byte)((d & 0x000000ff) >> 0);
 
@@ -105,8 +103,9 @@ namespace System.Windows.Media.Imaging
                         gd = (byte)((gs * a + gd * (0xff - a)) >> 8);
                         bd = (byte)((bs * a + bd * (0xff - a)) >> 8);
 
-                        buffer[y * width + x] = (0xff << 24) | (rd << 16) | (gd << 8) | (bd << 0);
-                    }
+						// buffer[y * width + x] = (0xff << 24) | (rd << 16) | (gd << 8) | (bd << 0);
+						Marshal.WriteInt32( buffer.Add<Int32>( y * width + x ), ( 0xff << 24 ) | ( rd << 16 ) | ( gd << 8 ) | ( bd << 0 ) );
+					}
                 }
 
                 return;
@@ -147,9 +146,10 @@ namespace System.Windows.Media.Imaging
                         gs = g;
                         bs = b;
 
-                        d = buffer[y * width + x];
+                        //d = buffer[y * width + x];
+						d = Marshal.ReadInt32( buffer.Add<Int32>( y * width + x ) );
 
-                        rd = (byte)((d & 0x00ff0000) >> 16);
+						rd = (byte)((d & 0x00ff0000) >> 16);
                         gd = (byte)((d & 0x0000ff00) >> 8);
                         bd = (byte)((d & 0x000000ff) >> 0);
 
@@ -157,9 +157,10 @@ namespace System.Windows.Media.Imaging
                         gd = (byte)((gs * a + gd * (0xff - a)) >> 8);
                         bd = (byte)((bs * a + bd * (0xff - a)) >> 8);
 
-                        buffer[y * width + x] = (0xff << 24) | (rd << 16) | (gd << 8) | (bd << 0);
-                    }
-                }
+                        //buffer[y * width + x] = (0xff << 24) | (rd << 16) | (gd << 8) | (bd << 0);
+						Marshal.WriteInt32( buffer.Add<Int32>( y * width + x ), ( 0xff << 24 ) | ( rd << 16 ) | ( gd << 8 ) | ( bd << 0 ) );
+					}
+				}
 
                 return;
             }
@@ -284,9 +285,10 @@ namespace System.Windows.Media.Imaging
                     gs = g;
                     bs = b;
 
-                    d = buffer[y * width + x];
+					//d = buffer[y * width + x];
+					d = Marshal.ReadInt32( buffer.Add<Int32>( y * width + x ) );
 
-                    rd = (byte)((d & 0x00ff0000) >> 16);
+					rd = (byte)((d & 0x00ff0000) >> 16);
                     gd = (byte)((d & 0x0000ff00) >> 8);
                     bd = (byte)((d & 0x000000ff) >> 0);
 
@@ -294,9 +296,10 @@ namespace System.Windows.Media.Imaging
                     gd = (byte)((gs * a + gd * (0xff - a)) >> 8);
                     bd = (byte)((bs * a + bd * (0xff - a)) >> 8);
 
-                    buffer[y * width + x] = (0xff << 24) | (rd << 16) | (gd << 8) | (bd << 0);
-                }
-            }
+					//buffer[y * width + x] = (0xff << 24) | (rd << 16) | (gd << 8) | (bd << 0);
+					Marshal.WriteInt32( buffer.Add<Int32>( y * width + x ), ( 0xff << 24 ) | ( rd << 16 ) | ( gd << 8 ) | ( bd << 0 ) );
+				}
+			}
         }
 
         private static void Swap<T>(ref T a, ref T b)
@@ -381,9 +384,10 @@ namespace System.Windows.Media.Imaging
                     gs = g;
                     bs = b;
 
-                    d = buffer[y * width + x];
+                    //d = buffer[y * width + x];
+					d = Marshal.ReadInt32( buffer.Add<Int32>( y * width + x ) );
 
-                    rd = (byte)((d & 0x00ff0000) >> 16);
+					rd = (byte)((d & 0x00ff0000) >> 16);
                     gd = (byte)((d & 0x0000ff00) >> 8);
                     bd = (byte)((d & 0x000000ff) >> 0);
 
@@ -391,11 +395,10 @@ namespace System.Windows.Media.Imaging
                     gd = (byte)((gs * ta + gd * (0xff - ta)) >> 8);
                     bd = (byte)((bs * ta + bd * (0xff - ta)) >> 8);
 
-                    buffer[y * width + x] = (0xff << 24) | (rd << 16) | (gd << 8) | (bd << 0);
-
-                    //
-                }
-            }
+                    //buffer[y * width + x] = (0xff << 24) | (rd << 16) | (gd << 8) | (bd << 0);
+					Marshal.WriteInt32( buffer.Add<Int32>( y * width + x ), ( 0xff << 24 ) | ( rd << 16 ) | ( gd << 8 ) | ( bd << 0 ) );
+				}
+			}
             else
             {
                 off ^= 0xff;
@@ -423,9 +426,10 @@ namespace System.Windows.Media.Imaging
                     gs = g;
                     bs = b;
 
-                    d = buffer[y * width + x];
+					//d = buffer[y * width + x];
+					d = Marshal.ReadInt32( buffer.Add<Int32>( y * width + x ) );
 
-                    rd = (byte)((d & 0x00ff0000) >> 16);
+					rd = (byte)((d & 0x00ff0000) >> 16);
                     gd = (byte)((d & 0x0000ff00) >> 8);
                     bd = (byte)((d & 0x000000ff) >> 0);
 
@@ -433,9 +437,10 @@ namespace System.Windows.Media.Imaging
                     gd = (byte)((gs * ta + gd * (0xff - ta)) >> 8);
                     bd = (byte)((bs * ta + bd * (0xff - ta)) >> 8);
 
-                    buffer[y * width + x] = (0xff << 24) | (rd << 16) | (gd << 8) | (bd << 0);
+                    //buffer[y * width + x] = (0xff << 24) | (rd << 16) | (gd << 8) | (bd << 0);
+					Marshal.WriteInt32( buffer.Add<Int32>( y * width + x ), ( 0xff << 24 ) | ( rd << 16 ) | ( gd << 8 ) | ( bd << 0 ) );
 
-                    if (leftEdge) leftEdgeX[y] = x + 1;
+					if (leftEdge) leftEdgeX[y] = x + 1;
                     else rightEdgeX[y] = x - 1;
                 }
             }

--- a/Source/WriteableBitmapEx/WriteableBitmapBaseExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapBaseExtensions.cs
@@ -17,6 +17,7 @@
 #endregion
 
 using System;
+using System.Runtime.InteropServices;
 
 #if NETFX_CORE
 namespace Windows.UI.Xaml.Media.Imaging
@@ -24,457 +25,476 @@ namespace Windows.UI.Xaml.Media.Imaging
 namespace System.Windows.Media.Imaging
 #endif
 {
-    /// <summary>
-    /// Collection of extension methods for the WriteableBitmap class.
-    /// </summary>
-    public
-#if WPF 
-    unsafe 
-#endif
- static partial class WriteableBitmapExtensions
-    {
-        #region Fields
+	/// <summary>
+	/// Collection of extension methods for the WriteableBitmap class.
+	/// </summary>
+	public static partial class WriteableBitmapExtensions
+	{
+		#region Fields
 
-        internal const int SizeOfArgb = 4;
+		internal const int SizeOfArgb = 4;
 
-        #endregion
+		#endregion
 
-        #region Methods
+		#region Methods
 
-        #region General
+		#region General
 
-        public static int ConvertColor(double opacity, Color color)
-        {
-            if (opacity < 0.0 || opacity > 1.0)
-            {
-                throw new ArgumentOutOfRangeException("opacity", "Opacity must be between 0.0 and 1.0");
-            }
+		public static int ConvertColor( double opacity, Color color )
+		{
+			if( opacity < 0.0 || opacity > 1.0 )
+			{
+				throw new ArgumentOutOfRangeException( "opacity", "Opacity must be between 0.0 and 1.0" );
+			}
 
-            color.A = (byte)(color.A * opacity);
+			color.A = (byte)( color.A * opacity );
 
-            return ConvertColor(color);
-        }
+			return ConvertColor( color );
+		}
 
-        public static int ConvertColor(Color color)
-        {
-            var col = 0;
+		public static int ConvertColor( Color color )
+		{
+			var col = 0;
 
-            if (color.A != 0)
-            {
-                var a = color.A + 1;
-                col = (color.A << 24)
-                  | ((byte)((color.R * a) >> 8) << 16)
-                  | ((byte)((color.G * a) >> 8) << 8)
-                  | ((byte)((color.B * a) >> 8));
-            }
+			if( color.A != 0 )
+			{
+				var a = color.A + 1;
+				col = ( color.A << 24 )
+				  | ( (byte)( ( color.R * a ) >> 8 ) << 16 )
+				  | ( (byte)( ( color.G * a ) >> 8 ) << 8 )
+				  | ( (byte)( ( color.B * a ) >> 8 ) );
+			}
 
-            return col;
-        }
+			return col;
+		}
 
-        /// <summary>
-        /// Fills the whole WriteableBitmap with a color.
-        /// </summary>
-        /// <param name="bmp">The WriteableBitmap.</param>
-        /// <param name="color">The color used for filling.</param>
-        public static void Clear(this WriteableBitmap bmp, Color color)
-        {
-            var col = ConvertColor(color);
-            using (var context = bmp.GetBitmapContext())
-            {
-                var pixels = context.Pixels;
-                var w = context.Width;
-                var h = context.Height;
-                var len = w * SizeOfArgb;
+		/// <summary>
+		/// Fills the whole WriteableBitmap with a color.
+		/// </summary>
+		/// <param name="bmp">The WriteableBitmap.</param>
+		/// <param name="color">The color used for filling.</param>
+		public static void Clear( this WriteableBitmap bmp, Color color )
+		{
+			var col = ConvertColor( color );
+			using( var context = bmp.GetBitmapContext() )
+			{
+				var pixels = context.Pixels;
+				var w = context.Width;
+				var h = context.Height;
+				var len = w * SizeOfArgb;
 
-                // Fill first line
-                for (var x = 0; x < w; x++)
-                {
-                    pixels[x] = col;
-                }
+				// Fill first line
+				for( var x = 0; x < w; x++ )
+				{
+					//pixels[x] = col;
+					Marshal.WriteInt32( pixels.Add<Int32>( x ), col );
+				}
 
-                // Copy first line
-                var blockHeight = 1;
-                var y = 1;
-                while (y < h)
-                {
-                    BitmapContext.BlockCopy(context, 0, context, y * len, blockHeight * len);
-                    y += blockHeight;
-                    blockHeight = Math.Min(2 * blockHeight, h - y);
-                }
-            }
-        }
+				// Copy first line
+				var blockHeight = 1;
+				var y = 1;
+				while( y < h )
+				{
+					BitmapContext.BlockCopy( context, 0, context, y * len, blockHeight * len );
+					y += blockHeight;
+					blockHeight = Math.Min( 2 * blockHeight, h - y );
+				}
+			}
+		}
 
-        /// <summary>
-        /// Fills the whole WriteableBitmap with an empty color (0).
-        /// </summary>
-        /// <param name="bmp">The WriteableBitmap.</param>
-        public static void Clear(this WriteableBitmap bmp)
-        {
-            using (var context = bmp.GetBitmapContext())
-            {
-                context.Clear();
-            }
-        }
+		/// <summary>
+		/// Fills the whole WriteableBitmap with an empty color (0).
+		/// </summary>
+		/// <param name="bmp">The WriteableBitmap.</param>
+		public static void Clear( this WriteableBitmap bmp )
+		{
+			using( var context = bmp.GetBitmapContext() )
+			{
+				context.Clear();
+			}
+		}
 
-        /// <summary>
-        /// Clones the specified WriteableBitmap.
-        /// </summary>
-        /// <param name="bmp">The WriteableBitmap.</param>
-        /// <returns>A copy of the WriteableBitmap.</returns>
-        public static WriteableBitmap Clone(this WriteableBitmap bmp)
-        {
-            using (var srcContext = bmp.GetBitmapContext(ReadWriteMode.ReadOnly))
-            {
-                var result = BitmapFactory.New(srcContext.Width, srcContext.Height);
-                using (var destContext = result.GetBitmapContext())
-                {
-                    BitmapContext.BlockCopy(srcContext, 0, destContext, 0, srcContext.Length * SizeOfArgb);
-                }
-                return result;
-            }
-        }
+		/// <summary>
+		/// Clones the specified WriteableBitmap.
+		/// </summary>
+		/// <param name="bmp">The WriteableBitmap.</param>
+		/// <returns>A copy of the WriteableBitmap.</returns>
+		public static WriteableBitmap Clone( this WriteableBitmap bmp )
+		{
+			using( var srcContext = bmp.GetBitmapContext( ReadWriteMode.ReadOnly ) )
+			{
+				var result = BitmapFactory.New( srcContext.Width, srcContext.Height );
+				using( var destContext = result.GetBitmapContext() )
+				{
+					BitmapContext.BlockCopy( srcContext, 0, destContext, 0, srcContext.Length * SizeOfArgb );
+				}
+				return result;
+			}
+		}
 
-        #endregion
+		#endregion
 
-        #region ForEach
+		#region ForEach
 
-        /// <summary>
-        /// Applies the given function to all the pixels of the bitmap in 
-        /// order to set their color.
-        /// </summary>
-        /// <param name="bmp">The WriteableBitmap.</param>
-        /// <param name="func">The function to apply. With parameters x, y and a color as a result</param>
-        public static void ForEach(this WriteableBitmap bmp, Func<int, int, Color> func)
-        {
-            using (var context = bmp.GetBitmapContext())
-            {
-                var pixels = context.Pixels;
-                int w = context.Width;
-                int h = context.Height;
-                int index = 0;
+		/// <summary>
+		/// Applies the given function to all the pixels of the bitmap in 
+		/// order to set their color.
+		/// </summary>
+		/// <param name="bmp">The WriteableBitmap.</param>
+		/// <param name="func">The function to apply. With parameters x, y and a color as a result</param>
+		public static void ForEach( this WriteableBitmap bmp, Func<int, int, Color> func )
+		{
+			using( var context = bmp.GetBitmapContext() )
+			{
+				var pixels = context.Pixels;
+				int w = context.Width;
+				int h = context.Height;
+				int index = 0;
 
-                for (int y = 0; y < h; y++)
-                {
-                    for (int x = 0; x < w; x++)
-                    {
-                        var color = func(x, y);
-                        pixels[index++] = ConvertColor(color);
-                    }
-                }
-            }
-        }
+				for( int y = 0; y < h; y++ )
+				{
+					for( int x = 0; x < w; x++ )
+					{
+						var color = func( x, y );
+						//pixels[index++] = ConvertColor(color);
+						Marshal.WriteInt32( pixels.Add<Int32>( index++ ), ConvertColor( color ) );
+					}
+				}
+			}
+		}
 
-        /// <summary>
-        /// Applies the given function to all the pixels of the bitmap in 
-        /// order to set their color.
-        /// </summary>
-        /// <param name="bmp">The WriteableBitmap.</param>
-        /// <param name="func">The function to apply. With parameters x, y, source color and a color as a result</param>
-        public static void ForEach(this WriteableBitmap bmp, Func<int, int, Color, Color> func)
-        {
-            using (var context = bmp.GetBitmapContext())
-            {
-                var pixels = context.Pixels;
-                var w = context.Width;
-                var h = context.Height;
-                var index = 0;
+		/// <summary>
+		/// Applies the given function to all the pixels of the bitmap in 
+		/// order to set their color.
+		/// </summary>
+		/// <param name="bmp">The WriteableBitmap.</param>
+		/// <param name="func">The function to apply. With parameters x, y, source color and a color as a result</param>
+		public static void ForEach( this WriteableBitmap bmp, Func<int, int, Color, Color> func )
+		{
+			using( var context = bmp.GetBitmapContext() )
+			{
+				var pixels = context.Pixels;
+				var w = context.Width;
+				var h = context.Height;
+				var index = 0;
 
-                for (var y = 0; y < h; y++)
-                {
-                    for (var x = 0; x < w; x++)
-                    {
-                        var c = pixels[index];
+				for( var y = 0; y < h; y++ )
+				{
+					for( var x = 0; x < w; x++ )
+					{
+						//var c = pixels[index];
+						Int32 c = Marshal.ReadInt32( pixels.Add<Int32>( index ) );
 
-                        // Premultiplied Alpha!
-                        var a = (byte)(c >> 24);
-                        // Prevent division by zero
-                        int ai = a;
-                        if (ai == 0)
-                        {
-                            ai = 1;
-                        }
-                        // Scale inverse alpha to use cheap integer mul bit shift
-                        ai = ((255 << 8) / ai);
-                        var srcColor = Color.FromArgb(a,
-                                                      (byte)((((c >> 16) & 0xFF) * ai) >> 8),
-                                                      (byte)((((c >> 8) & 0xFF) * ai) >> 8),
-                                                      (byte)((((c & 0xFF) * ai) >> 8)));
+						// Premultiplied Alpha!
+						var a = (byte)( c >> 24 );
+						// Prevent division by zero
+						int ai = a;
+						if( ai == 0 )
+						{
+							ai = 1;
+						}
+						// Scale inverse alpha to use cheap integer mul bit shift
+						ai = ( ( 255 << 8 ) / ai );
+						var srcColor = Color.FromArgb( a,
+													  (byte)( ( ( ( c >> 16 ) & 0xFF ) * ai ) >> 8 ),
+													  (byte)( ( ( ( c >> 8 ) & 0xFF ) * ai ) >> 8 ),
+													  (byte)( ( ( ( c & 0xFF ) * ai ) >> 8 ) ) );
 
-                        var color = func(x, y, srcColor);
-                        pixels[index++] = ConvertColor(color);
-                    }
-                }
-            }
-        }
+						var color = func( x, y, srcColor );
+						//pixels[index++] = ConvertColor(color);
+						Marshal.WriteInt32( pixels.Add<Int32>( index++ ), ConvertColor( color ) );
+					}
+				}
+			}
+		}
 
-        #endregion
+		#endregion
 
-        #region Get Pixel / Brightness
+		#region Get Pixel / Brightness
 
-        /// <summary>
-        /// Gets the color of the pixel at the x, y coordinate as integer.  
-        /// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
-        /// </summary>
-        /// <param name="bmp">The WriteableBitmap.</param>
-        /// <param name="x">The x coordinate of the pixel.</param>
-        /// <param name="y">The y coordinate of the pixel.</param>
-        /// <returns>The color of the pixel at x, y.</returns>
-        public static int GetPixeli(this WriteableBitmap bmp, int x, int y)
-        {
-            using (var context = bmp.GetBitmapContext())
-            {
-                return context.Pixels[y * context.Width + x];
-            }
-        }
+		/// <summary>
+		/// Gets the color of the pixel at the x, y coordinate as integer.  
+		/// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
+		/// </summary>
+		/// <param name="bmp">The WriteableBitmap.</param>
+		/// <param name="x">The x coordinate of the pixel.</param>
+		/// <param name="y">The y coordinate of the pixel.</param>
+		/// <returns>The color of the pixel at x, y.</returns>
+		public static int GetPixeli( this WriteableBitmap bmp, int x, int y )
+		{
+			using( var context = bmp.GetBitmapContext() )
+			{
+				// return context.Pixels[y * context.Width + x];
+				return ( Marshal.ReadInt32( context.Pixels.Add<Int32>( y * context.Width + x ) ) );
+			}
+		}
 
-        /// <summary>
-        /// Gets the color of the pixel at the x, y coordinate as a Color struct.  
-        /// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
-        /// </summary>
-        /// <param name="bmp">The WriteableBitmap.</param>
-        /// <param name="x">The x coordinate of the pixel.</param>
-        /// <param name="y">The y coordinate of the pixel.</param>
-        /// <returns>The color of the pixel at x, y as a Color struct.</returns>
-        public static Color GetPixel(this WriteableBitmap bmp, int x, int y)
-        {
-            using (var context = bmp.GetBitmapContext())
-            {
-                var c = context.Pixels[y * context.Width + x];
-                var a = (byte)(c >> 24);
+		/// <summary>
+		/// Gets the color of the pixel at the x, y coordinate as a Color struct.  
+		/// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
+		/// </summary>
+		/// <param name="bmp">The WriteableBitmap.</param>
+		/// <param name="x">The x coordinate of the pixel.</param>
+		/// <param name="y">The y coordinate of the pixel.</param>
+		/// <returns>The color of the pixel at x, y as a Color struct.</returns>
+		public static Color GetPixel( this WriteableBitmap bmp, int x, int y )
+		{
+			using( var context = bmp.GetBitmapContext() )
+			{
+				//var c = context.Pixels[y * context.Width + x];
+				var c = Marshal.ReadInt32( context.Pixels.Add<Int32>( y * context.Width + x ) );
+				var a = (byte)( c >> 24 );
 
-                // Prevent division by zero
-                int ai = a;
-                if (ai == 0)
-                {
-                    ai = 1;
-                }
+				// Prevent division by zero
+				int ai = a;
+				if( ai == 0 )
+				{
+					ai = 1;
+				}
 
-                // Scale inverse alpha to use cheap integer mul bit shift
-                ai = ((255 << 8) / ai);
-                return Color.FromArgb(a,
-                                     (byte)((((c >> 16) & 0xFF) * ai) >> 8),
-                                     (byte)((((c >> 8) & 0xFF) * ai) >> 8),
-                                     (byte)((((c & 0xFF) * ai) >> 8)));
-            }
-        }
+				// Scale inverse alpha to use cheap integer mul bit shift
+				ai = ( ( 255 << 8 ) / ai );
+				return Color.FromArgb( a,
+									 (byte)( ( ( ( c >> 16 ) & 0xFF ) * ai ) >> 8 ),
+									 (byte)( ( ( ( c >> 8 ) & 0xFF ) * ai ) >> 8 ),
+									 (byte)( ( ( ( c & 0xFF ) * ai ) >> 8 ) ) );
+			}
+		}
 
-        /// <summary>
-        /// Gets the brightness / luminance of the pixel at the x, y coordinate as byte.
-        /// </summary>
-        /// <param name="bmp">The WriteableBitmap.</param>
-        /// <param name="x">The x coordinate of the pixel.</param>
-        /// <param name="y">The y coordinate of the pixel.</param>
-        /// <returns>The brightness of the pixel at x, y.</returns>
-        public static byte GetBrightness(this WriteableBitmap bmp, int x, int y)
-        {
-            using (var context = bmp.GetBitmapContext(ReadWriteMode.ReadOnly))
-            {
-                // Extract color components
-                var c = context.Pixels[y * context.Width + x];
-                var r = (byte)(c >> 16);
-                var g = (byte)(c >> 8);
-                var b = (byte)(c);
+		/// <summary>
+		/// Gets the brightness / luminance of the pixel at the x, y coordinate as byte.
+		/// </summary>
+		/// <param name="bmp">The WriteableBitmap.</param>
+		/// <param name="x">The x coordinate of the pixel.</param>
+		/// <param name="y">The y coordinate of the pixel.</param>
+		/// <returns>The brightness of the pixel at x, y.</returns>
+		public static byte GetBrightness( this WriteableBitmap bmp, int x, int y )
+		{
+			using( var context = bmp.GetBitmapContext( ReadWriteMode.ReadOnly ) )
+			{
+				// Extract color components
+				// var c = context.Pixels[y * context.Width + x];
+				var c = Marshal.ReadInt32( context.Pixels.Add<Int32>( y * context.Width + x ) );
+				var r = (byte)( c >> 16 );
+				var g = (byte)( c >> 8 );
+				var b = (byte)( c );
 
-                // Convert to gray with constant factors 0.2126, 0.7152, 0.0722
-                return (byte)((r * 6966 + g * 23436 + b * 2366) >> 15);
-            }
-        }
+				// Convert to gray with constant factors 0.2126, 0.7152, 0.0722
+				return (byte)( ( r * 6966 + g * 23436 + b * 2366 ) >> 15 );
+			}
+		}
 
-        #endregion
+		#endregion
 
-        #region SetPixel
+		#region SetPixel
 
-        #region Without alpha
+		#region Without alpha
 
-        /// <summary>
-        /// Sets the color of the pixel using a precalculated index (faster). 
-        /// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
-        /// </summary>
-        /// <param name="bmp">The WriteableBitmap.</param>
-        /// <param name="index">The coordinate index.</param>
-        /// <param name="r">The red value of the color.</param>
-        /// <param name="g">The green value of the color.</param>
-        /// <param name="b">The blue value of the color.</param>
-        public static void SetPixeli(this WriteableBitmap bmp, int index, byte r, byte g, byte b)
-        {
-            using (var context = bmp.GetBitmapContext())
-            {
-                context.Pixels[index] = (255 << 24) | (r << 16) | (g << 8) | b;
-            }
-        }
+		/// <summary>
+		/// Sets the color of the pixel using a precalculated index (faster). 
+		/// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
+		/// </summary>
+		/// <param name="bmp">The WriteableBitmap.</param>
+		/// <param name="index">The coordinate index.</param>
+		/// <param name="r">The red value of the color.</param>
+		/// <param name="g">The green value of the color.</param>
+		/// <param name="b">The blue value of the color.</param>
+		public static void SetPixeli( this WriteableBitmap bmp, int index, byte r, byte g, byte b )
+		{
+			using( var context = bmp.GetBitmapContext() )
+			{
+				//context.Pixels[index] = (255 << 24) | (r << 16) | (g << 8) | b;
+				Marshal.WriteInt32( context.Pixels.Add<Int32>( index ), ( 255 << 24 ) | ( r << 16 ) | ( g << 8 ) | b );
+			}
+		}
 
-        /// <summary>
-        /// Sets the color of the pixel. 
-        /// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
-        /// </summary>
-        /// <param name="bmp">The WriteableBitmap.</param>
-        /// <param name="x">The x coordinate (row).</param>
-        /// <param name="y">The y coordinate (column).</param>
-        /// <param name="r">The red value of the color.</param>
-        /// <param name="g">The green value of the color.</param>
-        /// <param name="b">The blue value of the color.</param>
-        public static void SetPixel(this WriteableBitmap bmp, int x, int y, byte r, byte g, byte b)
-        {
-            using (var context = bmp.GetBitmapContext())
-            {
-                context.Pixels[y * context.Width + x] = (255 << 24) | (r << 16) | (g << 8) | b;
-            }
-        }
+		/// <summary>
+		/// Sets the color of the pixel. 
+		/// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
+		/// </summary>
+		/// <param name="bmp">The WriteableBitmap.</param>
+		/// <param name="x">The x coordinate (row).</param>
+		/// <param name="y">The y coordinate (column).</param>
+		/// <param name="r">The red value of the color.</param>
+		/// <param name="g">The green value of the color.</param>
+		/// <param name="b">The blue value of the color.</param>
+		public static void SetPixel( this WriteableBitmap bmp, int x, int y, byte r, byte g, byte b )
+		{
+			using( var context = bmp.GetBitmapContext() )
+			{
+				//context.Pixels[y * context.Width + x] = (255 << 24) | (r << 16) | (g << 8) | b;
+				Marshal.WriteInt32( context.Pixels.Add<Int32>( y * context.Width + x ), ( 255 << 24 ) | ( r << 16 ) | ( g << 8 ) | b );
+			}
+		}
 
-        #endregion
+		#endregion
 
-        #region With alpha
+		#region With alpha
 
-        /// <summary>
-        /// Sets the color of the pixel including the alpha value and using a precalculated index (faster). 
-        /// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
-        /// </summary>
-        /// <param name="bmp">The WriteableBitmap.</param>
-        /// <param name="index">The coordinate index.</param>
-        /// <param name="a">The alpha value of the color.</param>
-        /// <param name="r">The red value of the color.</param>
-        /// <param name="g">The green value of the color.</param>
-        /// <param name="b">The blue value of the color.</param>
-        public static void SetPixeli(this WriteableBitmap bmp, int index, byte a, byte r, byte g, byte b)
-        {
-            using (var context = bmp.GetBitmapContext())
-            {
-                context.Pixels[index] = (a << 24) | (r << 16) | (g << 8) | b;
-            }
-        }
+		/// <summary>
+		/// Sets the color of the pixel including the alpha value and using a precalculated index (faster). 
+		/// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
+		/// </summary>
+		/// <param name="bmp">The WriteableBitmap.</param>
+		/// <param name="index">The coordinate index.</param>
+		/// <param name="a">The alpha value of the color.</param>
+		/// <param name="r">The red value of the color.</param>
+		/// <param name="g">The green value of the color.</param>
+		/// <param name="b">The blue value of the color.</param>
+		public static void SetPixeli( this WriteableBitmap bmp, int index, byte a, byte r, byte g, byte b )
+		{
+			using( var context = bmp.GetBitmapContext() )
+			{
+				//context.Pixels[index] = (a << 24) | (r << 16) | (g << 8) | b;
+				Marshal.WriteInt32( context.Pixels.Add<Int32>( index ), ( a << 24 ) | ( r << 16 ) | ( g << 8 ) | b );
+			}
+		}
 
-        /// <summary>
-        /// Sets the color of the pixel including the alpha value. 
-        /// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
-        /// </summary>
-        /// <param name="bmp">The WriteableBitmap.</param>
-        /// <param name="x">The x coordinate (row).</param>
-        /// <param name="y">The y coordinate (column).</param>
-        /// <param name="a">The alpha value of the color.</param>
-        /// <param name="r">The red value of the color.</param>
-        /// <param name="g">The green value of the color.</param>
-        /// <param name="b">The blue value of the color.</param>
-        public static void SetPixel(this WriteableBitmap bmp, int x, int y, byte a, byte r, byte g, byte b)
-        {
-            using (var context = bmp.GetBitmapContext())
-            {
-                context.Pixels[y * context.Width + x] = (a << 24) | (r << 16) | (g << 8) | b;
-            }
-        }
+		/// <summary>
+		/// Sets the color of the pixel including the alpha value. 
+		/// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
+		/// </summary>
+		/// <param name="bmp">The WriteableBitmap.</param>
+		/// <param name="x">The x coordinate (row).</param>
+		/// <param name="y">The y coordinate (column).</param>
+		/// <param name="a">The alpha value of the color.</param>
+		/// <param name="r">The red value of the color.</param>
+		/// <param name="g">The green value of the color.</param>
+		/// <param name="b">The blue value of the color.</param>
+		public static void SetPixel( this WriteableBitmap bmp, int x, int y, byte a, byte r, byte g, byte b )
+		{
+			using( var context = bmp.GetBitmapContext() )
+			{
+				//context.Pixels[y * context.Width + x] = (a << 24) | (r << 16) | (g << 8) | b;
+				Marshal.WriteInt32( context.Pixels.Add<Int32>( y * context.Width + x ), ( a << 24 ) | ( r << 16 ) | ( g << 8 ) | b );
+			}
+		}
 
-        #endregion
+		#endregion
 
-        #region With System.Windows.Media.Color
+		#region With System.Windows.Media.Color
 
-        /// <summary>
-        /// Sets the color of the pixel using a precalculated index (faster). 
-        /// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
-        /// </summary>
-        /// <param name="bmp">The WriteableBitmap.</param>
-        /// <param name="index">The coordinate index.</param>
-        /// <param name="color">The color.</param>
-        public static void SetPixeli(this WriteableBitmap bmp, int index, Color color)
-        {
-            using (var context = bmp.GetBitmapContext())
-            {
-                context.Pixels[index] = ConvertColor(color);
-            }
-        }
+		/// <summary>
+		/// Sets the color of the pixel using a precalculated index (faster). 
+		/// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
+		/// </summary>
+		/// <param name="bmp">The WriteableBitmap.</param>
+		/// <param name="index">The coordinate index.</param>
+		/// <param name="color">The color.</param>
+		public static void SetPixeli( this WriteableBitmap bmp, int index, Color color )
+		{
+			using( var context = bmp.GetBitmapContext() )
+			{
+				//context.Pixels[index] = ConvertColor(color);
+				Marshal.WriteInt32( context.Pixels.Add<Int32>( index ), ConvertColor( color ) );
+			}
+		}
 
-        /// <summary>
-        /// Sets the color of the pixel. 
-        /// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
-        /// </summary>
-        /// <param name="bmp">The WriteableBitmap.</param>
-        /// <param name="x">The x coordinate (row).</param>
-        /// <param name="y">The y coordinate (column).</param>
-        /// <param name="color">The color.</param>
-        public static void SetPixel(this WriteableBitmap bmp, int x, int y, Color color)
-        {
-            using (var context = bmp.GetBitmapContext())
-            {
-                context.Pixels[y * context.Width + x] = ConvertColor(color);
-            }
-        }
+		/// <summary>
+		/// Sets the color of the pixel. 
+		/// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
+		/// </summary>
+		/// <param name="bmp">The WriteableBitmap.</param>
+		/// <param name="x">The x coordinate (row).</param>
+		/// <param name="y">The y coordinate (column).</param>
+		/// <param name="color">The color.</param>
+		public static void SetPixel( this WriteableBitmap bmp, int x, int y, Color color )
+		{
+			using( var context = bmp.GetBitmapContext() )
+			{
+				//context.Pixels[y * context.Width + x] = ConvertColor(color);
+				Marshal.WriteInt32( context.Pixels.Add<Int32>( y * context.Width + x ), ConvertColor( color ) );
+			}
+		}
 
-        /// <summary>
-        /// Sets the color of the pixel using an extra alpha value and a precalculated index (faster). 
-        /// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
-        /// </summary>
-        /// <param name="bmp">The WriteableBitmap.</param>
-        /// <param name="index">The coordinate index.</param>
-        /// <param name="a">The alpha value of the color.</param>
-        /// <param name="color">The color.</param>
-        public static void SetPixeli(this WriteableBitmap bmp, int index, byte a, Color color)
-        {
-            using (var context = bmp.GetBitmapContext())
-            {
-                // Add one to use mul and cheap bit shift for multiplicaltion
-                var ai = a + 1;
-                context.Pixels[index] = (a << 24)
-                           | ((byte)((color.R * ai) >> 8) << 16)
-                           | ((byte)((color.G * ai) >> 8) << 8)
-                           | ((byte)((color.B * ai) >> 8));
-            }
-        }
+		/// <summary>
+		/// Sets the color of the pixel using an extra alpha value and a precalculated index (faster). 
+		/// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
+		/// </summary>
+		/// <param name="bmp">The WriteableBitmap.</param>
+		/// <param name="index">The coordinate index.</param>
+		/// <param name="a">The alpha value of the color.</param>
+		/// <param name="color">The color.</param>
+		public static void SetPixeli( this WriteableBitmap bmp, int index, byte a, Color color )
+		{
+			using( var context = bmp.GetBitmapContext() )
+			{
+				// Add one to use mul and cheap bit shift for multiplicaltion
+				var ai = a + 1;
+				//context.Pixels[index] = (a << 24)
+				//           | ((byte)((color.R * ai) >> 8) << 16)
+				//           | ((byte)((color.G * ai) >> 8) << 8)
+				//           | ((byte)((color.B * ai) >> 8));
+				Marshal.WriteInt32( context.Pixels.Add<Int32>( index ),
+								( a << 24 )
+							   | ( (byte)( ( color.R * ai ) >> 8 ) << 16 )
+							   | ( (byte)( ( color.G * ai ) >> 8 ) << 8 )
+							   | ( (byte)( ( color.B * ai ) >> 8 ) ) );
+			}
+		}
 
-        /// <summary>
-        /// Sets the color of the pixel using an extra alpha value. 
-        /// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
-        /// </summary>
-        /// <param name="bmp">The WriteableBitmap.</param>
-        /// <param name="x">The x coordinate (row).</param>
-        /// <param name="y">The y coordinate (column).</param>
-        /// <param name="a">The alpha value of the color.</param>
-        /// <param name="color">The color.</param>
-        public static void SetPixel(this WriteableBitmap bmp, int x, int y, byte a, Color color)
-        {
-            using (var context = bmp.GetBitmapContext())
-            {
-                // Add one to use mul and cheap bit shift for multiplicaltion
-                var ai = a + 1;
-                context.Pixels[y * context.Width + x] = (a << 24)
-                                             | ((byte)((color.R * ai) >> 8) << 16)
-                                             | ((byte)((color.G * ai) >> 8) << 8)
-                                             | ((byte)((color.B * ai) >> 8));
-            }
-        }
+		/// <summary>
+		/// Sets the color of the pixel using an extra alpha value. 
+		/// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
+		/// </summary>
+		/// <param name="bmp">The WriteableBitmap.</param>
+		/// <param name="x">The x coordinate (row).</param>
+		/// <param name="y">The y coordinate (column).</param>
+		/// <param name="a">The alpha value of the color.</param>
+		/// <param name="color">The color.</param>
+		public static void SetPixel( this WriteableBitmap bmp, int x, int y, byte a, Color color )
+		{
+			using( var context = bmp.GetBitmapContext() )
+			{
+				// Add one to use mul and cheap bit shift for multiplicaltion
+				var ai = a + 1;
+				//context.Pixels[y * context.Width + x] = (a << 24)
+				//                             | ((byte)((color.R * ai) >> 8) << 16)
+				//                             | ((byte)((color.G * ai) >> 8) << 8)
+				//                             | ((byte)((color.B * ai) >> 8));
+				Marshal.WriteInt32( context.Pixels.Add<Int32>( y * context.Width + x ), ( a << 24 )
+							 | ( (byte)( ( color.R * ai ) >> 8 ) << 16 )
+							 | ( (byte)( ( color.G * ai ) >> 8 ) << 8 )
+							 | ( (byte)( ( color.B * ai ) >> 8 ) ) );
+			}
+		}
 
-        /// <summary>
-        /// Sets the color of the pixel using a precalculated index (faster).  
-        /// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
-        /// </summary>
-        /// <param name="bmp">The WriteableBitmap.</param>
-        /// <param name="index">The coordinate index.</param>
-        /// <param name="color">The color.</param>
-        public static void SetPixeli(this WriteableBitmap bmp, int index, int color)
-        {
-            using (var context = bmp.GetBitmapContext())
-            {
-                context.Pixels[index] = color;
-            }
-        }
+		/// <summary>
+		/// Sets the color of the pixel using a precalculated index (faster).  
+		/// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
+		/// </summary>
+		/// <param name="bmp">The WriteableBitmap.</param>
+		/// <param name="index">The coordinate index.</param>
+		/// <param name="color">The color.</param>
+		public static void SetPixeli( this WriteableBitmap bmp, int index, int color )
+		{
+			using( var context = bmp.GetBitmapContext() )
+			{
+				//context.Pixels[index] = color;
+				Marshal.WriteInt32( context.Pixels.Add<Int32>( index ), color );
+			}
+		}
 
-        /// <summary>
-        /// Sets the color of the pixel. 
-        /// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
-        /// </summary>
-        /// <param name="bmp">The WriteableBitmap.</param>
-        /// <param name="x">The x coordinate (row).</param>
-        /// <param name="y">The y coordinate (column).</param>
-        /// <param name="color">The color.</param>
-        public static void SetPixel(this WriteableBitmap bmp, int x, int y, int color)
-        {
-            using (var context = bmp.GetBitmapContext())
-            {
-                context.Pixels[y * context.Width + x] = color;
-            }
-        }
+		/// <summary>
+		/// Sets the color of the pixel. 
+		/// For best performance this method should not be used in iterative real-time scenarios. Implement the code directly inside a loop.
+		/// </summary>
+		/// <param name="bmp">The WriteableBitmap.</param>
+		/// <param name="x">The x coordinate (row).</param>
+		/// <param name="y">The y coordinate (column).</param>
+		/// <param name="color">The color.</param>
+		public static void SetPixel( this WriteableBitmap bmp, int x, int y, int color )
+		{
+			using( var context = bmp.GetBitmapContext() )
+			{
+				//context.Pixels[y * context.Width + x] = color;
+				Marshal.WriteInt32( context.Pixels.Add<Int32>( y * context.Width + x ), color );
+			}
+		}
+		#endregion
 
-        #endregion
+		#endregion
 
-        #endregion
-
-        #endregion
-    }
+		#endregion
+	}
 }

--- a/Source/WriteableBitmapEx/WriteableBitmapConvertExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapConvertExtensions.cs
@@ -19,6 +19,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 
 #if NETFX_CORE
 using Windows.ApplicationModel.Resources;
@@ -36,11 +37,7 @@ namespace System.Windows.Media.Imaging
     /// <summary>
     /// Collection of interchange extension methods for the WriteableBitmap class.
     /// </summary>
-    public
-#if WPF
- unsafe
-#endif
- static partial class WriteableBitmapExtensions
+    public static partial class WriteableBitmapExtensions
     {
         #region Methods
 
@@ -159,9 +156,10 @@ namespace System.Windows.Media.Imaging
                 {
                     for (int x = 0; x < width; x++)
                     {
-                        // Account for pre-multiplied alpha
-                        int c = pixels[offsetSource];
-                        var a = (byte)(c >> 24);
+						// Account for pre-multiplied alpha
+						//int c = pixels[offsetSource];
+						int c = Marshal.ReadInt32( pixels.Add<Int32>( offsetSource ) );
+						var a = (byte)(c >> 24);
 
                         // Prevent division by zero
                         int ai = a;

--- a/Source/WriteableBitmapEx/WriteableBitmapFillExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapFillExtensions.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 #if NETFX_CORE
 namespace Windows.UI.Xaml.Media.Imaging
@@ -28,11 +29,7 @@ namespace System.Windows.Media.Imaging
     /// <summary>
     /// Collection of extension methods for the WriteableBitmap class.
     /// </summary>
-    public
-#if WPF
-    unsafe
-#endif
- static partial class WriteableBitmapExtensions
+    public static partial class WriteableBitmapExtensions
     {
         #region Methods
 
@@ -115,11 +112,12 @@ namespace System.Windows.Media.Imaging
                 var endOffset = startY + x2;
                 for (var idx = startYPlusX1; idx < endOffset; idx++)
                 {
-                    pixels[idx] = noBlending ? color : AlphaBlendColors(pixels[idx], sa, sr, sg, sb);
-                }
+					//pixels[idx] = noBlending ? color : AlphaBlendColors(pixels[idx], sa, sr, sg, sb);
+					Marshal.WriteInt32( pixels.Add<Int32>( idx ), noBlending ? color : AlphaBlendColors( Marshal.ReadInt32( pixels.Add<Int32>( idx ) ), sa, sr, sg, sb ) );
+				}
 
-                // Copy first line
-                var len = (x2 - x1);
+				// Copy first line
+				var len = (x2 - x1);
                 var srcOffsetBytes = startYPlusX1 * SizeOfArgb;
                 var offset2 = y2 * w + x1;
                 for (var y = startYPlusX1 + w; y < offset2; y += w)
@@ -134,9 +132,11 @@ namespace System.Windows.Media.Imaging
                     for (int i = 0; i < len; i++)
                     {
                         int idx = y + i;
-                        pixels[idx] = AlphaBlendColors(pixels[idx], sa, sr, sg, sb);
-                    }
-                }
+						//pixels[idx] = AlphaBlendColors(pixels[idx], sa, sr, sg, sb);
+						IntPtr dest = pixels.Add<Int32>( idx );
+						Marshal.WriteInt32( dest, AlphaBlendColors( Marshal.ReadInt32( dest ), sa, sr, sg, sb ) );
+					}
+				}
             }
         }
 
@@ -293,14 +293,16 @@ namespace System.Windows.Media.Imaging
                     // Draw line
                     for (int i = lx; i <= rx; i++)
                     {
-                        // Quadrant II to I (Actually two octants)
-                        pixels[i + uh] = noBlending ? color : AlphaBlendColors(pixels[i + uh], sa, sr, sg, sb);
+						// Quadrant II to I (Actually two octants)
+						// pixels[i + uh] = noBlending ? color : AlphaBlendColors(pixels[i + uh], sa, sr, sg, sb);
+						Marshal.WriteInt32( pixels.Add<Int32>( i + uh ), noBlending ? color : AlphaBlendColors( Marshal.ReadInt32( pixels.Add<Int32>( i + uh ) ), sa, sr, sg, sb ) );
 
-                        // Quadrant III to IV
-                        pixels[i + lh] = noBlending ? color : AlphaBlendColors(pixels[i + lh], sa, sr, sg, sb);
-                    }
+						// Quadrant III to IV
+						//pixels[i + lh] = noBlending ? color : AlphaBlendColors(pixels[i + lh], sa, sr, sg, sb);
+						Marshal.WriteInt32( pixels.Add<Int32>( i + lh ), noBlending ? color : AlphaBlendColors( Marshal.ReadInt32( pixels.Add<Int32>( i + lh ) ), sa, sr, sg, sb ) );
+					}
 
-                    y++;
+					y++;
                     yStopping += xrSqTwo;
                     err += yChg;
                     yChg += xrSqTwo;
@@ -355,11 +357,13 @@ namespace System.Windows.Media.Imaging
                     // Draw line
                     for (int i = lx; i <= rx; i++)
                     {
-                        pixels[i + uh] = color; // Quadrant II to I (Actually two octants)
-                        pixels[i + lh] = color; // Quadrant III to IV
-                    }
+						//pixels[i + uh] = color; // Quadrant II to I (Actually two octants)
+						Marshal.WriteInt32( pixels.Add<Int32>( i + uh ), color );
+						//pixels[i + lh] = color; // Quadrant III to IV
+						Marshal.WriteInt32( pixels.Add<Int32>( i + lh ), color );
+					}
 
-                    x++;
+					x++;
                     xStopping += yrSqTwo;
                     err += xChg;
                     xChg += yrSqTwo;
@@ -498,9 +502,10 @@ namespace System.Windows.Media.Imaging
                             {
                                 int idx = y * w + x;
 
-                                pixels[idx] = noBlending ? color : AlphaBlendColors(pixels[idx], sa, sr, sg, sb);
-                            }
-                        }
+								//pixels[idx] = noBlending ? color : AlphaBlendColors(pixels[idx], sa, sr, sg, sb);
+								Marshal.WriteInt32( pixels.Add<Int32>(idx), noBlending ? color : AlphaBlendColors( Marshal.ReadInt32( pixels.Add<Int32>( idx )), sa, sr, sg, sb ) );
+							}
+						}
                     }
                 }
             }
@@ -777,7 +782,8 @@ namespace System.Windows.Media.Imaging
                         int index = y * w + x0;
                         for (int x = x0; x <= x1; x++)
                         {
-                            pixels[index++] = color;
+							//pixels[index++] = color;
+							Marshal.WriteInt32( pixels.Add<Int32>( index++ ), color );
                         }
                     }
                 }

--- a/Source/WriteableBitmapEx/WriteableBitmapFilterExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapFilterExtensions.cs
@@ -17,6 +17,7 @@
 #endregion
 
 using System;
+using System.Runtime.InteropServices;
 
 #if NETFX_CORE
 namespace Windows.UI.Xaml.Media.Imaging
@@ -27,11 +28,7 @@ namespace System.Windows.Media.Imaging
     /// <summary>
     /// Collection of filter / convolution extension methods for the WriteableBitmap class.
     /// </summary>
-    public
-#if WPF
- unsafe
-#endif
- static partial class WriteableBitmapExtensions
+    public static partial class WriteableBitmapExtensions
     {
         #region Kernels
 
@@ -157,7 +154,8 @@ namespace System.Windows.Media.Imaging
                                         py = h - 1;
                                     }
 
-                                    var col = pixels[py * w + px];
+									//var col = pixels[py * w + px];
+									var col = Marshal.ReadInt32( pixels.Add<Int32>( py * w + px ) );
                                     var k = kernel[ky + kwh, kx + khh];
                                     a += ((col >> 24) & 0x000000FF) * k;
                                     r += ((col >> 16) & 0x000000FF) * k;
@@ -177,7 +175,8 @@ namespace System.Windows.Media.Imaging
                             var bg = (byte)((tg > 255) ? 255 : ((tg < 0) ? 0 : tg));
                             var bb = (byte)((tb > 255) ? 255 : ((tb < 0) ? 0 : tb));
 
-                            resultPixels[index++] = (ba << 24) | (br << 16) | (bg << 8) | (bb);
+							//resultPixels[index++] = (ba << 24) | (br << 16) | (bg << 8) | (bb);
+							Marshal.WriteInt32( resultPixels.Add<Int32>( index++ ), ( ba << 24 ) | ( br << 16 ) | ( bg << 8 ) | ( bb ) );
                         }
                     }
                     return result;
@@ -207,8 +206,9 @@ namespace System.Windows.Media.Imaging
 
                     for (var i = 0; i < length; i++)
                     {
-                        // Extract
-                        var c = p[i];
+						// Extract
+						// var c = p[i];
+						var c = Marshal.ReadInt32( p.Add<Int32>( i ));
                         var a = (c >> 24) & 0x000000FF;
                         var r = (c >> 16) & 0x000000FF;
                         var g = (c >> 8) & 0x000000FF;
@@ -219,11 +219,12 @@ namespace System.Windows.Media.Imaging
                         g = 255 - g;
                         b = 255 - b;
 
-                        // Set
-                        rp[i] = (a << 24) | (r << 16) | (g << 8) | b;
-                    }
+						// Set
+						//rp[i] = (a << 24) | (r << 16) | (g << 8) | b;
+						Marshal.WriteInt32( rp.Add<Int32>( i ), ( a << 24 ) | ( r << 16 ) | ( g << 8 ) | b );
+					}
 
-                    return result;
+					return result;
                 }
             }
         }
@@ -252,9 +253,10 @@ namespace System.Windows.Media.Imaging
                     var len = context.Length;
                     for (var i = 0; i < len; i++)
                     {
-                        // Extract
-                        var c = px[i];
-                        var a = (c >> 24) & 0x000000FF;
+						// Extract
+						//var c = px[i];
+						var c = Marshal.ReadInt32( px.Add<Int32>( i ) );
+						var a = (c >> 24) & 0x000000FF;
                         var r = (c >> 16) & 0x000000FF;
                         var g = (c >> 8) & 0x000000FF;
                         var b = (c) & 0x000000FF;
@@ -264,9 +266,10 @@ namespace System.Windows.Media.Imaging
                         r = g = b = gray;
 
                         // Set
-                        rp[i] = (a << 24) | (r << 16) | (g << 8) | b;
-                    }
-                }
+                        //rp[i] = (a << 24) | (r << 16) | (g << 8) | b;
+						Marshal.WriteInt32( rp.Add<Int32>( i ), ( a << 24 ) | ( r << 16 ) | ( g << 8 ) | b );
+					}
+				}
 
                 return result;
             }
@@ -295,9 +298,10 @@ namespace System.Windows.Media.Imaging
                     var len = context.Length;
                     for (var i = 0; i < len; i++)
                     {
-                        // Extract
-                        var c = px[i];
-                        var a = (c >> 24) & 0x000000FF;
+						// Extract
+						//var c = px[i];
+						var c = Marshal.ReadInt32( px.Add<Int32>( i ) );
+						var a = (c >> 24) & 0x000000FF;
                         var r = (c >> 16) & 0x000000FF;
                         var g = (c >> 8) & 0x000000FF;
                         var b = (c) & 0x000000FF;
@@ -313,9 +317,10 @@ namespace System.Windows.Media.Imaging
                         b = b < 0 ? 0 : b > 255 ? 255 : b;
 
                         // Set
-                        rp[i] = (a << 24) | (r << 16) | (g << 8) | b;
-                    }
-                }
+                        //rp[i] = (a << 24) | (r << 16) | (g << 8) | b;
+						Marshal.WriteInt32( rp.Add<Int32>( i ), ( a << 24 ) | ( r << 16 ) | ( g << 8 ) | b );
+					}
+				}
 
                 return result;
             }
@@ -343,8 +348,9 @@ namespace System.Windows.Media.Imaging
                     for (var i = 0; i < len; i++)
                     {
                         // Extract
-                        var c = px[i];
-                        var a = (c >> 24) & 0x000000FF;
+                        //var c = px[i];
+						var c = Marshal.ReadInt32( px.Add<Int32>( i ) );
+						var a = (c >> 24) & 0x000000FF;
                         var r = (c >> 16) & 0x000000FF;
                         var g = (c >> 8) & 0x000000FF;
                         var b = (c) & 0x000000FF;
@@ -360,9 +366,10 @@ namespace System.Windows.Media.Imaging
                         b = b < 0 ? 0 : b > 255 ? 255 : b;
 
                         // Set
-                        rp[i] = (a << 24) | (r << 16) | (g << 8) | b;
-                    }
-                }
+                        //rp[i] = (a << 24) | (r << 16) | (g << 8) | b;
+						Marshal.WriteInt32( rp.Add<Int32>( i ), ( a << 24 ) | ( r << 16 ) | ( g << 8 ) | b );
+					}
+				}
 
                 return result;
             }
@@ -390,9 +397,10 @@ namespace System.Windows.Media.Imaging
                     var len = context.Length;
                     for (var i = 0; i < len; i++)
                     {
-                        // Extract
-                        var c = px[i];
-                        var a = (c >> 24) & 0x000000FF;
+						// Extract
+						//var c = px[i];
+						var c = Marshal.ReadInt32( px.Add<Int32>( i ) );
+						var a = (c >> 24) & 0x000000FF;
                         var r = (c >> 16) & 0x000000FF;
                         var g = (c >> 8) & 0x000000FF;
                         var b = (c) & 0x000000FF;
@@ -407,10 +415,11 @@ namespace System.Windows.Media.Imaging
                         g = g < 0 ? 0 : g > 255 ? 255 : g;
                         b = b < 0 ? 0 : b > 255 ? 255 : b;
 
-                        // Set
-                        rp[i] = (a << 24) | (r << 16) | (g << 8) | b;
-                    }
-                }
+						// Set
+						//rp[i] = (a << 24) | (r << 16) | (g << 8) | b;
+						Marshal.WriteInt32( rp.Add<Int32>( i ), ( a << 24 ) | ( r << 16 ) | ( g << 8 ) | b );
+					}
+				}
 
                 return result;
             }

--- a/Source/WriteableBitmapEx/WriteableBitmapLineExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapLineExtensions.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 #if NETFX_CORE
 using Windows.Foundation;
@@ -27,11 +28,7 @@ namespace Windows.UI.Xaml.Media.Imaging
 namespace System.Windows.Media.Imaging
 #endif
 {
-    public
-#if WPF
-        unsafe
-#endif
- static partial class WriteableBitmapExtensions
+    public static partial class WriteableBitmapExtensions
     {
         #region Normal line
 
@@ -123,7 +120,8 @@ namespace System.Windows.Media.Imaging
                 int error = el >> 1;
                 if (y < h && y >= 0 && x < w && x >= 0)
                 {
-                    pixels[y * w + x] = color;
+					//pixels[y * w + x] = color;
+					Marshal.WriteInt32( pixels.Add<Int32>( y * w + x ), color );
                 }
 
                 // Walk the line!
@@ -148,9 +146,10 @@ namespace System.Windows.Media.Imaging
                     // Set pixel
                     if (y < h && y >= 0 && x < w && x >= 0)
                     {
-                        pixels[y * w + x] = color;
-                    }
-                }
+						//pixels[y * w + x] = color;
+						Marshal.WriteInt32( pixels.Add<Int32>( y * w + x ), color );
+					}
+				}
             }
         }
 
@@ -213,9 +212,10 @@ namespace System.Windows.Media.Imaging
                     {
                         if (y < h && y >= 0 && x < w && x >= 0)
                         {
-                            pixels[(int)y * w + (int)x] = color;
-                        }
-                        x += incx;
+							//pixels[(int)y * w + (int)x] = color;
+							Marshal.WriteInt32( pixels.Add<Int32>( (int)y * w + (int)x ), color );
+						}
+						x += incx;
                         y += incy;
                     }
                 }
@@ -395,8 +395,9 @@ namespace System.Windows.Media.Imaging
                 int k = incy < 0 ? 1 - pixelWidth : 1 + pixelWidth;
                 for (int x = x1; x <= x2; ++x)
                 {
-                    pixels[index] = color;
-                    ys += incy;
+					//pixels[index] = color;
+					Marshal.WriteInt32( pixels.Add<Int32>( index ), color );
+					ys += incy;
                     y = ys >> PRECISION_SHIFT;
                     if (y != previousY)
                     {
@@ -508,8 +509,9 @@ namespace System.Windows.Media.Imaging
                 var inc = (pixelWidth << PRECISION_SHIFT) + incx;
                 for (int y = y1; y <= y2; ++y)
                 {
-                    pixels[indexBaseValue + (index >> PRECISION_SHIFT)] = color;
-                    index += inc;
+					//pixels[indexBaseValue + (index >> PRECISION_SHIFT)] = color;
+					Marshal.WriteInt32( pixels.Add<Int32>( indexBaseValue + ( index >> PRECISION_SHIFT ) ), color );
+					index += inc;
                 }
             }
         }
@@ -759,11 +761,12 @@ namespace System.Windows.Media.Imaging
                 tmp = x1; x1 = x2; x2 = tmp;
             }
 
-            // draw initial pixel, which is always intersected by line to it's at 100% intensity
-            pixels[y1 * pixelWidth + x1] = AlphaBlend(sa, sr, sg, sb, pixels[y1 * pixelWidth + x1]);
-            //bitmap.SetPixel(X0, Y0, BaseColor);
+			// draw initial pixel, which is always intersected by line to it's at 100% intensity
+			//pixels[y1 * pixelWidth + x1] = AlphaBlend(sa, sr, sg, sb, pixels[y1 * pixelWidth + x1]);
+			Marshal.WriteInt32( pixels.Add<Int32>( y1 * pixelWidth + x1 ), AlphaBlend( sa, sr, sg, sb, Marshal.ReadInt32( pixels.Add<Int32>( y1 * pixelWidth + x1 ) ) ) );
+			//bitmap.SetPixel(X0, Y0, BaseColor);
 
-            DeltaX = (short)(x2 - x1);
+			DeltaX = (short)(x2 - x1);
             if (DeltaX >= 0)
             {
                 XDir = 1;
@@ -783,9 +786,10 @@ namespace System.Windows.Media.Imaging
                 while (DeltaX-- != 0)
                 {
                     x1 += XDir;
-                    pixels[y1 * pixelWidth + x1] = AlphaBlend(sa, sr, sg, sb, pixels[y1 * pixelWidth + x1]);
-                }
-                return;
+					//pixels[y1 * pixelWidth + x1] = AlphaBlend(sa, sr, sg, sb, pixels[y1 * pixelWidth + x1]);
+					Marshal.WriteInt32( pixels.Add<Int32>( y1 * pixelWidth + x1 ), AlphaBlend( sa, sr, sg, sb, Marshal.ReadInt32( pixels.Add<Int32>( y1 * pixelWidth + x1 ) ) ) );
+				}
+				return;
             }
 
             if (DeltaX == 0) // if vertical line 
@@ -793,8 +797,9 @@ namespace System.Windows.Media.Imaging
                 do
                 {
                     y1++;
-                    pixels[y1 * pixelWidth + x1] = AlphaBlend(sa, sr, sg, sb, pixels[y1 * pixelWidth + x1]);
-                } while (--DeltaY != 0);
+					//pixels[y1 * pixelWidth + x1] = AlphaBlend(sa, sr, sg, sb, pixels[y1 * pixelWidth + x1]);
+					Marshal.WriteInt32( pixels.Add<Int32>( y1 * pixelWidth + x1 ), AlphaBlend( sa, sr, sg, sb, Marshal.ReadInt32( pixels.Add<Int32>( y1 * pixelWidth + x1 ) ) ) );
+				} while (--DeltaY != 0);
                 return;
             }
 
@@ -804,8 +809,9 @@ namespace System.Windows.Media.Imaging
                 {
                     x1 += XDir;
                     y1++;
-                    pixels[y1 * pixelWidth + x1] = AlphaBlend(sa, sr, sg, sb, pixels[y1 * pixelWidth + x1]);
-                } while (--DeltaY != 0);
+					//pixels[y1 * pixelWidth + x1] = AlphaBlend(sa, sr, sg, sb, pixels[y1 * pixelWidth + x1]);
+					Marshal.WriteInt32( pixels.Add<Int32>( y1 * pixelWidth + x1 ), AlphaBlend( sa, sr, sg, sb, Marshal.ReadInt32( pixels.Add<Int32>( y1 * pixelWidth + x1 ) ) ) );
+				} while (--DeltaY != 0);
                 return;
             }
 
@@ -837,19 +843,22 @@ namespace System.Windows.Media.Imaging
                     Weighting = (ushort)(ErrorAcc >> INTENSITY_SHIFT);
 
                     int weight = Weighting ^ WEIGHT_COMPLEMENT_MASK;
-                    pixels[y1 * pixelWidth + x1] = AlphaBlend(sa, (sr * weight) >> 8, (sg * weight) >> 8, (sb * weight) >> 8, pixels[y1 * pixelWidth + x1]);
+					//pixels[y1 * pixelWidth + x1] = AlphaBlend(sa, (sr * weight) >> 8, (sg * weight) >> 8, (sb * weight) >> 8, pixels[y1 * pixelWidth + x1]);
+					Marshal.WriteInt32( pixels.Add<Int32>( y1 * pixelWidth + x1 ), AlphaBlend( sa, ( sr * weight ) >> 8, ( sg * weight ) >> 8, ( sb * weight ) >> 8, Marshal.ReadInt32( pixels.Add<Int32>( y1 * pixelWidth + x1 ) ) ) );
 
-                    weight = Weighting;
-                    pixels[y1 * pixelWidth + x1 + XDir] = AlphaBlend(sa, (sr * weight) >> 8, (sg * weight) >> 8, (sb * weight) >> 8, pixels[y1 * pixelWidth + x1 + XDir]);
+					weight = Weighting;
+					//pixels[y1 * pixelWidth + x1 + XDir] = AlphaBlend(sa, (sr * weight) >> 8, (sg * weight) >> 8, (sb * weight) >> 8, pixels[y1 * pixelWidth + x1 + XDir]);
+					Marshal.WriteInt32( pixels.Add<Int32>( y1 * pixelWidth + x1 + XDir ), AlphaBlend( sa, ( sr * weight ) >> 8, ( sg * weight ) >> 8, ( sb * weight ) >> 8, Marshal.ReadInt32( pixels.Add<Int32>( y1 * pixelWidth + x1 + XDir ) ) ) );
 
-                    //bitmap.SetPixel(X0, Y0, 255 - (BaseColor + Weighting));
-                    //bitmap.SetPixel(X0 + XDir, Y0, 255 - (BaseColor + (Weighting ^ WeightingComplementMask)));
-                }
+					//bitmap.SetPixel(X0, Y0, 255 - (BaseColor + Weighting));
+					//bitmap.SetPixel(X0 + XDir, Y0, 255 - (BaseColor + (Weighting ^ WeightingComplementMask)));
+				}
 
-                // Draw the final pixel, which is always exactly intersected by the line and so needs no weighting
-                pixels[y2 * pixelWidth + x2] = AlphaBlend(sa, sr, sg, sb, pixels[y2 * pixelWidth + x2]);
-                //bitmap.SetPixel(X1, Y1, BaseColor);
-                return;
+				// Draw the final pixel, which is always exactly intersected by the line and so needs no weighting
+				//pixels[y2 * pixelWidth + x2] = AlphaBlend(sa, sr, sg, sb, pixels[y2 * pixelWidth + x2]);
+				Marshal.WriteInt32( pixels.Add<Int32>( y2 * pixelWidth + x2 ), AlphaBlend( sa, sr, sg, sb, Marshal.ReadInt32( pixels.Add<Int32>( y2 * pixelWidth + x2 ) ) ) );
+				//bitmap.SetPixel(X1, Y1, BaseColor);
+				return;
             }
             // It's an X-major line; calculate 16-bit fixed-point fractional part of a
             // pixel that Y advances each time X advances 1 pixel, truncating the
@@ -873,31 +882,34 @@ namespace System.Windows.Media.Imaging
                 Weighting = (ushort)(ErrorAcc >> INTENSITY_SHIFT);
 
                 int weight = Weighting ^ WEIGHT_COMPLEMENT_MASK;
-                pixels[y1 * pixelWidth + x1] = AlphaBlend(sa, (sr * weight) >> 8, (sg * weight) >> 8, (sb * weight) >> 8, pixels[y1 * pixelWidth + x1]);
+				//pixels[y1 * pixelWidth + x1] = AlphaBlend(sa, (sr * weight) >> 8, (sg * weight) >> 8, (sb * weight) >> 8, pixels[y1 * pixelWidth + x1]);
+				Marshal.WriteInt32( pixels.Add<Int32>( y1 * pixelWidth + x1 ), AlphaBlend( sa, ( sr * weight ) >> 8, ( sg * weight ) >> 8, ( sb * weight ) >> 8, Marshal.ReadInt32( pixels.Add<Int32>( y1 * pixelWidth + x1 ) ) ) );
 
-                weight = Weighting;
-                pixels[(y1 + 1) * pixelWidth + x1] = AlphaBlend(sa, (sr * weight) >> 8, (sg * weight) >> 8, (sb * weight) >> 8, pixels[(y1 + 1) * pixelWidth + x1]);
+				weight = Weighting;
+				//pixels[(y1 + 1) * pixelWidth + x1] = AlphaBlend(sa, (sr * weight) >> 8, (sg * weight) >> 8, (sb * weight) >> 8, pixels[(y1 + 1) * pixelWidth + x1]);
+				Marshal.WriteInt32( pixels.Add<Int32>( ( y1 + 1 ) * pixelWidth + x1 ), AlphaBlend( sa, ( sr * weight ) >> 8, ( sg * weight ) >> 8, ( sb * weight ) >> 8, Marshal.ReadInt32( pixels.Add<Int32>( ( y1 + 1 ) * pixelWidth + x1 ) ) ) );
 
-                //bitmap.SetPixel(X0, Y0, 255 - (BaseColor + Weighting));
-                //bitmap.SetPixel(X0, Y0 + 1,
-                //      255 - (BaseColor + (Weighting ^ WeightingComplementMask)));
-            }
-            // Draw the final pixel, which is always exactly intersected by the line and thus needs no weighting 
-            pixels[y2 * pixelWidth + x2] = AlphaBlend(sa, sr, sg, sb, pixels[y2 * pixelWidth + x2]);
-            //bitmap.SetPixel(X1, Y1, BaseColor);
-        }
+				//bitmap.SetPixel(X0, Y0, 255 - (BaseColor + Weighting));
+				//bitmap.SetPixel(X0, Y0 + 1,
+				//      255 - (BaseColor + (Weighting ^ WeightingComplementMask)));
+			}
+			// Draw the final pixel, which is always exactly intersected by the line and thus needs no weighting 
+			//pixels[y2 * pixelWidth + x2] = AlphaBlend(sa, sr, sg, sb, pixels[y2 * pixelWidth + x2]);
+			Marshal.WriteInt32( pixels.Add<Int32>( y2 * pixelWidth + x2 ), AlphaBlend( sa, sr, sg, sb, Marshal.ReadInt32( pixels.Add<Int32>( y2 * pixelWidth + x2 ) ) ) );
+			//bitmap.SetPixel(X1, Y1, BaseColor);
+		}
 
-        /// <summary> 
-        /// Draws an anti-aliased line with a desired stroke thickness
-        /// <param name="context">The context containing the pixels as int RGBA value.</param>
-        /// <param name="x1">The x-coordinate of the start point.</param>
-        /// <param name="y1">The y-coordinate of the start point.</param>
-        /// <param name="x2">The x-coordinate of the end point.</param>
-        /// <param name="y2">The y-coordinate of the end point.</param>
-        /// <param name="color">The color for the line.</param>
-        /// <param name="strokeThickness">The stroke thickness of the line.</param>
-        /// </summary>
-        public static void DrawLineAa(BitmapContext context, int pixelWidth, int pixelHeight, int x1, int y1, int x2, int y2, int color, int strokeThickness)
+		/// <summary> 
+		/// Draws an anti-aliased line with a desired stroke thickness
+		/// <param name="context">The context containing the pixels as int RGBA value.</param>
+		/// <param name="x1">The x-coordinate of the start point.</param>
+		/// <param name="y1">The y-coordinate of the start point.</param>
+		/// <param name="x2">The x-coordinate of the end point.</param>
+		/// <param name="y2">The y-coordinate of the end point.</param>
+		/// <param name="color">The color for the line.</param>
+		/// <param name="strokeThickness">The stroke thickness of the line.</param>
+		/// </summary>
+		public static void DrawLineAa(BitmapContext context, int pixelWidth, int pixelHeight, int x1, int y1, int x2, int y2, int color, int strokeThickness)
         {
             AAWidthLine(pixelWidth, pixelHeight, context, x1, y1, x2, y2, strokeThickness, color);
         }
@@ -1122,25 +1134,31 @@ namespace System.Windows.Media.Imaging
         private static void AlphaBlendNormalOnPremultiplied(BitmapContext context, int index, int sa, uint srb, uint sg)
         {
             var pixels = context.Pixels;
-            var destPixel = (uint)pixels[index];
+			//var destPixel = (uint)pixels[index];
+			var destPixel = (uint)Marshal.ReadInt32( pixels.Add<Int32>( index ) );
 
-            var da = (destPixel >> 24);
+			var da = (destPixel >> 24);
             var dg = ((destPixel >> 8) & 0xff);
             var drb = destPixel & 0x00FF00FF;
 
-            // blend with high-quality alpha and lower quality but faster 1-off RGBs 
-            pixels[index] = (int)(
-               ((sa + ((da * (255 - sa) * 0x8081) >> 23)) << 24) | // alpha 
-               (((sg - dg) * sa + (dg << 8)) & 0xFFFFFF00) | // green 
-               (((((srb - drb) * sa) >> 8) + drb) & 0x00FF00FF) // red and blue 
-            );
-        }
+			// blend with high-quality alpha and lower quality but faster 1-off RGBs 
+			//pixels[index] = (int)(
+			//   ((sa + ((da * (255 - sa) * 0x8081) >> 23)) << 24) | // alpha 
+			//   (((sg - dg) * sa + (dg << 8)) & 0xFFFFFF00) | // green 
+			//   (((((srb - drb) * sa) >> 8) + drb) & 0x00FF00FF) // red and blue 
+			//);
+			Marshal.WriteInt32( pixels.Add<Int32>( index ), (int)(
+			   ( ( sa + ( ( da * ( 255 - sa ) * 0x8081 ) >> 23 ) ) << 24 ) | // alpha 
+			   ( ( ( sg - dg ) * sa + ( dg << 8 ) ) & 0xFFFFFF00 ) | // green 
+			   ( ( ( ( ( srb - drb ) * sa ) >> 8 ) + drb ) & 0x00FF00FF ) // red and blue 
+			) );
+		}
 
-        #endregion
+		#endregion
 
-        #region Helper
+		#region Helper
 
-        internal static bool CohenSutherlandLineClipWithViewPortOffset(Rect viewPort, ref float xi0, ref float yi0, ref float xi1, ref float yi1, int offset)
+		internal static bool CohenSutherlandLineClipWithViewPortOffset(Rect viewPort, ref float xi0, ref float yi0, ref float xi1, ref float yi1, int offset)
         {
             var viewPortWithOffset = new Rect(viewPort.X - offset, viewPort.Y - offset, viewPort.Width + 2 * offset, viewPort.Height + 2 * offset);
 

--- a/Source/WriteableBitmapEx/WriteableBitmapShapeExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapShapeExtensions.cs
@@ -17,6 +17,7 @@
 #endregion
 
 using System;
+using System.Runtime.InteropServices;
 
 #if NETFX_CORE
 namespace Windows.UI.Xaml.Media.Imaging
@@ -27,11 +28,7 @@ namespace System.Windows.Media.Imaging
     /// <summary>
     /// Collection of extension methods for the WriteableBitmap class.
     /// </summary>
-    public
-#if WPF
-    unsafe
-#endif
- static partial class WriteableBitmapExtensions
+    public static partial class WriteableBitmapExtensions
     {
         #region Methods
 
@@ -274,9 +271,11 @@ namespace System.Windows.Media.Imaging
                 // top and bottom horizontal scanlines
                 for (var x = startYPlusX1; x <= endOffset; x++)
                 {
-                    pixels[x] = color; // top horizontal line
-                    pixels[offset2] = color; // bottom horizontal line
-                    offset2++;
+					//pixels[x] = color; // top horizontal line
+					Marshal.WriteInt32( pixels.Add<Int32>( x ), color );
+					//pixels[offset2] = color; // bottom horizontal line
+					Marshal.WriteInt32( pixels.Add<Int32>( offset2 ), color );
+					offset2++;
                 }
 
                 // offset2 == endY + x2
@@ -287,9 +286,11 @@ namespace System.Windows.Media.Imaging
 
                 for (var y = startY + x2 + w; y <= offset2; y += w)
                 {
-                    pixels[y] = color; // right vertical line
-                    pixels[endOffset] = color; // left vertical line
-                    endOffset += w;
+					//pixels[y] = color; // right vertical line
+					Marshal.WriteInt32( pixels.Add<Int32>( y ), color );
+					//pixels[endOffset] = color; // left vertical line
+					Marshal.WriteInt32( pixels.Add<Int32>( endOffset ), color );
+					endOffset += w;
                 }
             }
         }
@@ -407,12 +408,16 @@ namespace System.Windows.Media.Imaging
                     if (rx >= w) rx = w - 1;      // ...
                     if (lx < 0) lx = 0;
                     if (lx >= w) lx = w - 1;
-                    pixels[rx + uh] = color;      // Quadrant I (Actually an octant)
-                    pixels[lx + uh] = color;      // Quadrant II
-                    pixels[lx + lh] = color;      // Quadrant III
-                    pixels[rx + lh] = color;      // Quadrant IV
+					//pixels[rx + uh] = color;      // Quadrant I (Actually an octant)
+					Marshal.WriteInt32( pixels.Add<Int32>( rx + uh ), color );
+					//pixels[lx + uh] = color;      // Quadrant II
+					Marshal.WriteInt32( pixels.Add<Int32>( lx + uh ), color );
+					//pixels[lx + lh] = color;      // Quadrant III
+					Marshal.WriteInt32( pixels.Add<Int32>( lx + lh ), color );
+					//pixels[rx + lh] = color;      // Quadrant IV
+					Marshal.WriteInt32( pixels.Add<Int32>( rx + lh ), color );
 
-                    y++;
+					y++;
                     yStopping += xrSqTwo;
                     err += yChg;
                     yChg += xrSqTwo;
@@ -452,12 +457,16 @@ namespace System.Windows.Media.Imaging
                     if (rx >= w) rx = w - 1;      // ...
                     if (lx < 0) lx = 0;
                     if (lx >= w) lx = w - 1;
-                    pixels[rx + uh] = color;      // Quadrant I (Actually an octant)
-                    pixels[lx + uh] = color;      // Quadrant II
-                    pixels[lx + lh] = color;      // Quadrant III
-                    pixels[rx + lh] = color;      // Quadrant IV
+                    //pixels[rx + uh] = color;      // Quadrant I (Actually an octant)
+					Marshal.WriteInt32( pixels.Add<Int32>( rx + uh ), color );
+					//pixels[lx + uh] = color;      // Quadrant II
+					Marshal.WriteInt32( pixels.Add<Int32>( lx + uh ), color );
+					//pixels[lx + lh] = color;      // Quadrant III
+					Marshal.WriteInt32( pixels.Add<Int32>( lx + lh ), color );
+					//pixels[rx + lh] = color;      // Quadrant IV
+					Marshal.WriteInt32( pixels.Add<Int32>( rx + lh ), color );
 
-                    x++;
+					x++;
                     xStopping += yrSqTwo;
                     err += xChg;
                     xChg += yrSqTwo;

--- a/Source/WriteableBitmapEx/WriteableBitmapSplineExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapSplineExtensions.cs
@@ -27,11 +27,7 @@ namespace System.Windows.Media.Imaging
     /// <summary>
     /// Collection of draw spline extension methods for the WriteableBitmap class.
     /// </summary>
-    public
-#if WPF
-    unsafe
-#endif
- static partial class WriteableBitmapExtensions
+    public static partial class WriteableBitmapExtensions
     {
         #region Fields
 


### PR DESCRIPTION
Here is a version of the code without using the unsafe keyword in WPF. Reason for this change was I had a restriction where I could not use an unsafe .dll. I am providing my changes if there is interest.

Notes:
Performance hasn't been compared between the two versions. Though it seems great in what I was using it for. 
Spacing in the code that was changed was not set to match the project's standard.
The BlockCopy methods taking a src as an array or dest as an array in BitmapContet.cs file haven't been tested.
Have not tested with NETFX_CORE or SILVERLIGHT defined with the changed code.
