### PR TITLE
Update WriteableBitmapShapeExtensions.cs

### DIFF
--- a/Source/WriteableBitmapEx/WriteableBitmapShapeExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapShapeExtensions.cs
@@ -261,8 +261,8 @@ namespace System.Windows.Media.Imaging
                 if (y2 < 0) { y2 = 0; }
                 if (x1 >= w) { x1 = w - 1; }
                 if (y1 >= h) { y1 = h - 1; }
-                if (x2 > w) { x2 = w - 1; }
-                if (y2 > h) { y2 = h - 1; }
+                if (x2 >= w) { x2 = w - 1; }
+                if (y2 >= h) { y2 = h - 1; }
 
                 var startY = y1 * w;
                 var endY = y2 * w;


### PR DESCRIPTION
the DrawRectangle method ask to call with x1,x2 and y1,y2 coordinates
If i call with y2 = bitmap.Height or x2 = bitmap.Width the method crash! (unable to write memory..)