### PR TITLE
Bugfix: DrawPolylineAa draws polylines with gaps

### DIFF
--- a/Source/WriteableBitmapEx/WriteableBitmapLineExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapLineExtensions.cs
@@ -1108,7 +1108,7 @@ namespace System.Windows.Media.Imaging
                 }
                 u++;
                 addr += uincr;
-            } while (u < uend);
+            } while (u <= uend);
         }
 
         /// <summary> 


### PR DESCRIPTION
Fixed a drawing issue where gaps occur when using `DrawPolylineAa`. I fixed the problem by drawing one step further.