### PR TITLE
Don't need to call a Invalidate() function on Dispose()

### DIFF
--- a/Source/WriteableBitmapEx/BitmapContext.cs
+++ b/Source/WriteableBitmapEx/BitmapContext.cs
@@ -232,7 +232,10 @@ namespace System.Windows.Media.Imaging
       public void Dispose()
       {
          // For silverlight, do nothing except redraw
-          _writeableBitmap.Invalidate();
+          if (_mode == ReadWriteMode.ReadWrite)
+          {
+              _writeableBitmap.Invalidate();
+          }
       }
 
 #elif NETFX_CORE

--- a/Source/WriteableBitmapEx/WriteableBitmapBaseExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapBaseExtensions.cs
@@ -221,7 +221,7 @@ namespace System.Windows.Media.Imaging
         /// <returns>The color of the pixel at x, y.</returns>
         public static int GetPixeli(this WriteableBitmap bmp, int x, int y)
         {
-            using (var context = bmp.GetBitmapContext())
+            using (var context = bmp.GetBitmapContext(ReadWriteMode.ReadOnly))
             {
                 return context.Pixels[y * context.Width + x];
             }
@@ -237,7 +237,7 @@ namespace System.Windows.Media.Imaging
         /// <returns>The color of the pixel at x, y as a Color struct.</returns>
         public static Color GetPixel(this WriteableBitmap bmp, int x, int y)
         {
-            using (var context = bmp.GetBitmapContext())
+            using (var context = bmp.GetBitmapContext(ReadWriteMode.ReadOnly))
             {
                 var c = context.Pixels[y * context.Width + x];
                 var a = (byte)(c >> 24);

--- a/Source/WriteableBitmapEx/WriteableBitmapBlitExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapBlitExtensions.cs
@@ -541,7 +541,7 @@ namespace System.Windows.Media.Imaging
                 var inverse = transform.Inverse;
                 if(shouldClear) destContext.Clear();
 
-                using (BitmapContext sourceContext = source.GetBitmapContext())
+                using (BitmapContext sourceContext = source.GetBitmapContext(ReadWriteMode.ReadOnly))
                 {
                     var sourcePixels = sourceContext.Pixels;
                     int sourceWidth = sourceContext.Width;

--- a/Source/WriteableBitmapEx/WriteableBitmapConvertExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapConvertExtensions.cs
@@ -55,7 +55,7 @@ namespace System.Windows.Media.Imaging
         /// <returns>The color buffer as byte ARGB values.</returns>
         public static byte[] ToByteArray(this WriteableBitmap bmp, int offset, int count)
         {
-            using (var context = bmp.GetBitmapContext())
+            using (var context = bmp.GetBitmapContext(ReadWriteMode.ReadOnly))
             {
                 if (count == -1)
                 {
@@ -143,7 +143,7 @@ namespace System.Windows.Media.Imaging
         /// <param name="destination">The destination stream.</param>
         public static void WriteTga(this WriteableBitmap bmp, Stream destination)
         {
-            using (var context = bmp.GetBitmapContext())
+            using (var context = bmp.GetBitmapContext(ReadWriteMode.ReadOnly))
             {
                 int width = context.Width;
                 int height = context.Height;

--- a/Source/WriteableBitmapEx/WriteableBitmapFilterExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapFilterExtensions.cs
@@ -196,7 +196,7 @@ namespace System.Windows.Media.Imaging
         /// <returns>The new inverted WriteableBitmap.</returns>
         public static WriteableBitmap Invert(this WriteableBitmap bmp)
         {
-            using (var srcContext = bmp.GetBitmapContext())
+            using (var srcContext = bmp.GetBitmapContext(ReadWriteMode.ReadOnly))
             {
                 var result = BitmapFactory.New(srcContext.Width, srcContext.Height);
                 using (var resultContext = result.GetBitmapContext())
@@ -239,7 +239,7 @@ namespace System.Windows.Media.Imaging
         /// <returns>The new gray WriteableBitmap.</returns>
         public static WriteableBitmap Gray(this WriteableBitmap bmp)
         {
-            using (var context = bmp.GetBitmapContext())
+            using (var context = bmp.GetBitmapContext(ReadWriteMode.ReadOnly))
             {
                 var nWidth = context.Width;
                 var nHeight = context.Height;
@@ -282,7 +282,7 @@ namespace System.Windows.Media.Imaging
         {
             var factor = (int)((259.0 * (level + 255.0)) / (255.0 * (259.0 - level)) * 255.0);
 
-            using (var context = bmp.GetBitmapContext())
+            using (var context = bmp.GetBitmapContext(ReadWriteMode.ReadOnly))
             {
                 var nWidth = context.Width;
                 var nHeight = context.Height;
@@ -329,7 +329,7 @@ namespace System.Windows.Media.Imaging
         /// <returns>The new WriteableBitmap.</returns>
         public static WriteableBitmap AdjustBrightness(this WriteableBitmap bmp, int nLevel)
         {
-            using (var context = bmp.GetBitmapContext())
+            using (var context = bmp.GetBitmapContext(ReadWriteMode.ReadOnly))
             {
                 var nWidth = context.Width;
                 var nHeight = context.Height;
@@ -376,7 +376,7 @@ namespace System.Windows.Media.Imaging
         /// <returns>The new WriteableBitmap.</returns>
         public static WriteableBitmap AdjustGamma(this WriteableBitmap bmp, double value)
         {
-            using (var context = bmp.GetBitmapContext())
+            using (var context = bmp.GetBitmapContext(ReadWriteMode.ReadOnly))
             {
                 var nWidth = context.Width;
                 var nHeight = context.Height;

--- a/Source/WriteableBitmapEx/WriteableBitmapLineExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapLineExtensions.cs
@@ -590,7 +590,7 @@ namespace System.Windows.Media.Imaging
         {
             using (var context = bmp.GetBitmapContext())
             {
-                using (var penContext = penBmp.GetBitmapContext())
+                using (var penContext = penBmp.GetBitmapContext(ReadWriteMode.ReadOnly))
                 {
                     DrawLinePenned(context, bmp.PixelWidth, bmp.PixelHeight, x1, y1, x2, y2, penContext, clipRect);
                 }

--- a/Source/WriteableBitmapEx/WriteableBitmapTransformationExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapTransformationExtensions.cs
@@ -86,7 +86,7 @@ namespace System.Windows.Media.Imaging
         /// <returns>A new WriteableBitmap that is a cropped version of the input.</returns>
         public static WriteableBitmap Crop(this WriteableBitmap bmp, int x, int y, int width, int height)
         {
-            using (var srcContext = bmp.GetBitmapContext())
+            using (var srcContext = bmp.GetBitmapContext(ReadWriteMode.ReadOnly))
             {
                 var srcWidth = srcContext.Width;
                 var srcHeight = srcContext.Height;
@@ -143,7 +143,7 @@ namespace System.Windows.Media.Imaging
         /// <returns>A new WriteableBitmap that is a resized version of the input.</returns>
         public static WriteableBitmap Resize(this WriteableBitmap bmp, int width, int height, Interpolation interpolation)
         {
-            using (var srcContext = bmp.GetBitmapContext())
+            using (var srcContext = bmp.GetBitmapContext(ReadWriteMode.ReadOnly))
             {
                 var pd = Resize(srcContext, srcContext.Width, srcContext.Height, width, height, interpolation);
 
@@ -316,7 +316,7 @@ namespace System.Windows.Media.Imaging
         /// <returns>A new WriteableBitmap that is a rotated version of the input.</returns>
         public static WriteableBitmap Rotate(this WriteableBitmap bmp, int angle)
         {
-            using (var context = bmp.GetBitmapContext())
+            using (var context = bmp.GetBitmapContext(ReadWriteMode.ReadOnly))
             {
                 // Use refs for faster access (really important!) speeds up a lot!
                 var w = context.Width;
@@ -421,7 +421,7 @@ namespace System.Windows.Media.Imaging
             int iCentreX, iCentreY;
             int iDestCentreX, iDestCentreY;
             int iWidth, iHeight, newWidth, newHeight;
-            using (var bmpContext = bmp.GetBitmapContext())
+            using (var bmpContext = bmp.GetBitmapContext(ReadWriteMode.ReadOnly))
             {
 
                 iWidth = bmpContext.Width;
@@ -568,7 +568,7 @@ namespace System.Windows.Media.Imaging
         /// <returns>A new WriteableBitmap that is a flipped version of the input.</returns>
         public static WriteableBitmap Flip(this WriteableBitmap bmp, FlipMode flipMode)
         {
-            using (var context = bmp.GetBitmapContext())
+            using (var context = bmp.GetBitmapContext(ReadWriteMode.ReadOnly))
             {
                 // Use refs for faster access (really important!) speeds up a lot!
                 var w = context.Width;

--- a/Source/WriteableBitmapExBlitSample/ParticleEmitter.cs
+++ b/Source/WriteableBitmapExBlitSample/ParticleEmitter.cs
@@ -93,7 +93,7 @@ namespace WriteableBitmapExBlitSample
           }
           using (TargetBitmap.GetBitmapContext())
           {
-              using (ParticleBitmap.GetBitmapContext())
+              using (ParticleBitmap.GetBitmapContext(ReadWriteMode.ReadOnly))
               {
                   for (int i = 0; i < Particles.Count; i++)
                   {


### PR DESCRIPTION
 I think that it is not necessary to call a Invalidate() function for BitmapContext instance of the ReadOnly mode.
I want to use BitmapContext instance with ReadOnly on the worker thread.
But WriteableBitmap.Invalidate() is only for UI thread.