### PR TITLE
Fixed inaccurate method summary

### DIFF
--- a/Source/WriteableBitmapEx/WriteableBitmapShapeExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapShapeExtensions.cs
@@ -300,7 +300,7 @@ namespace System.Windows.Media.Imaging
 
         /// <summary>
         /// A Fast Bresenham Type Algorithm For Drawing Ellipses http://homepage.smc.edu/kennedy_john/belipse.pdf 
-        /// x2 has to be greater than x1 and y2 has to be greater than y1.
+        /// x2 has to be greater than x1 and y2 has to be less than y1.
         /// </summary>
         /// <param name="bmp">The WriteableBitmap.</param>
         /// <param name="x1">The x-coordinate of the bounding rectangle's left side.</param>
@@ -316,7 +316,7 @@ namespace System.Windows.Media.Imaging
 
         /// <summary>
         /// A Fast Bresenham Type Algorithm For Drawing Ellipses http://homepage.smc.edu/kennedy_john/belipse.pdf 
-        /// x2 has to be greater than x1 and y2 has to be greater than y1.
+        /// x2 has to be greater than x1 and y2 has to be less than y1.
         /// </summary>
         /// <param name="bmp">The WriteableBitmap.</param>
         /// <param name="x1">The x-coordinate of the bounding rectangle's left side.</param>


### PR DESCRIPTION
-y2 should be less than y1, not greater than. y2 is the bottom of the ellipse and y1 is the top.